### PR TITLE
Add snippet for defining functions

### DIFF
--- a/snippets/language-python.cson
+++ b/snippets/language-python.cson
@@ -26,6 +26,9 @@
   'New Method':
     'prefix': 'defs'
     'body': 'def ${1:mname}(self, ${2:arg}):\n\t${3:pass}'
+  'New Function':
+    'prefix': 'def'
+    'body': 'def ${1:fname}(${2:arg}):\n\t${3:pass}'
   'New Property':
     'prefix': 'property'
     'body': 'def ${1:foo}():\n    doc = "${2:The $1 property.}"\n    def fget(self):\n        ${3:return self._$1}\n    def fset(self, value):\n        ${4:self._$1 = value}\n    def fdel(self):\n        ${5:del self._$1}\n    return locals()\n$1 = property(**$1())$0'


### PR DESCRIPTION
The `defs` snippet defines only methods. We need a simple `def` snippet which expands to a simple one argument function.
