### PR TITLE
Break down flow into categories

### DIFF
--- a/grammars/python.cson
+++ b/grammars/python.cson
@@ -87,12 +87,12 @@
   }
   {
     'comment': 'keywords that delimit flow conditionals'
-    'name': 'keyword.control.flow.conditional.pytho'
+    'name': 'keyword.control.flow.conditional.python'
     'match': '\\b(if|elif|else)\\b'
   }
   {
     'comment': 'keywords that delimit an exception'
-    'name': 'keyword.control.flow.exception.pytho'
+    'name': 'keyword.control.flow.exception.python'
     'match': '\\b(except|finally|try|raise)\\b'
   }
   {


### PR DESCRIPTION
Add condition, exception, repeat, and statement as subcategories to
keyword.control.flow to allow for some vim-like theme features.
