### PR TITLE
Fix parsing of raw strings containing unclosed parentheses and brackets

### DIFF
--- a/grammars/python.cson
+++ b/grammars/python.cson
@@ -1001,10 +1001,10 @@
             'name': 'punctuation.definition.string.begin.python'
           '3':
             'patterns': [
-              'include': '#constant_placeholder'
-              'include': '#escaped_unicode_char'
-              'include': '#escaped_char'
-              'include': '#regular_expressions'
+              {'include': '#constant_placeholder'}
+              {'include': '#escaped_unicode_char'}
+              {'include': '#escaped_char'}
+              {'include': '#regular_expressions'}
             ]
           '4':
             'name': 'punctuation.definition.string.end.python'
@@ -1049,9 +1049,9 @@
             'name': 'punctuation.definition.string.begin.python'
           '3':
             'patterns': [
-              'include': '#constant_placeholder'
-              'include': '#escaped_char'
-              'include': '#regular_expressions'
+              {'include': '#constant_placeholder'}
+              {'include': '#escaped_char'}
+              {'include': '#regular_expressions'}
             ]
           '4':
             'name': 'punctuation.definition.string.end.python'
@@ -1369,10 +1369,10 @@
             'name': 'punctuation.definition.string.begin.python'
           '3':
             'patterns': [
-              'include': '#constant_placeholder'
-              'include': '#escaped_unicode_char'
-              'include': '#escaped_char'
-              'include': '#regular_expressions'
+              {'include': '#constant_placeholder'}
+              {'include': '#escaped_unicode_char'}
+              {'include': '#escaped_char'}
+              {'include': '#regular_expressions'}
             ]
           '4':
             'name': 'punctuation.definition.string.end.python'
@@ -1415,9 +1415,9 @@
             'name': 'punctuation.definition.string.begin.python'
           '3':
             'patterns': [
-              'include': '#constant_placeholder'
-              'include': '#escaped_char'
-              'include': '#regular_expressions'
+              {'include': '#constant_placeholder'}
+              {'include': '#escaped_char'}
+              {'include': '#regular_expressions'}
             ]
           '4':
             'name': 'punctuation.definition.string.end.python'

--- a/spec/python-spec.coffee
+++ b/spec/python-spec.coffee
@@ -37,145 +37,161 @@ describe "Python grammar", ->
     expect(tokens[1][2]).not.toBeDefined()
 
   it "terminates a single-quoted raw string containing opening parenthesis at closing quote", ->
-    tokens = grammar.tokenizeLines("r'(' #foo")
+    tokens = grammar.tokenizeLines("r'%d(' #foo")
 
     expect(tokens[0][0].value).toBe 'r'
     expect(tokens[0][0].scopes).toEqual ['source.python', 'string.quoted.single.single-line.raw-regex.python', 'storage.type.string.python']
     expect(tokens[0][1].value).toBe "'"
     expect(tokens[0][1].scopes).toEqual ['source.python', 'string.quoted.single.single-line.raw-regex.python', 'punctuation.definition.string.begin.python']
-    expect(tokens[0][2].value).toBe '('
-    expect(tokens[0][2].scopes).toEqual ['source.python', 'string.quoted.single.single-line.raw-regex.python', 'meta.group.regexp', 'punctuation.definition.group.regexp']
-    expect(tokens[0][3].value).toBe "'"
-    expect(tokens[0][3].scopes).toEqual ['source.python', 'string.quoted.single.single-line.raw-regex.python', 'punctuation.definition.string.end.python']
-    expect(tokens[0][4].value).toBe ' '
-    expect(tokens[0][4].scopes).toEqual ['source.python']
-    expect(tokens[0][5].value).toBe '#'
-    expect(tokens[0][5].scopes).toEqual ['source.python', 'comment.line.number-sign.python', 'punctuation.definition.comment.python']
-    expect(tokens[0][6].value).toBe 'foo'
-    expect(tokens[0][6].scopes).toEqual ['source.python', 'comment.line.number-sign.python']
+    expect(tokens[0][2].value).toBe '%d'
+    expect(tokens[0][2].scopes).toEqual ['source.python', 'string.quoted.single.single-line.raw-regex.python', 'constant.other.placeholder.python']
+    expect(tokens[0][3].value).toBe '('
+    expect(tokens[0][3].scopes).toEqual ['source.python', 'string.quoted.single.single-line.raw-regex.python', 'meta.group.regexp', 'punctuation.definition.group.regexp']
+    expect(tokens[0][4].value).toBe "'"
+    expect(tokens[0][4].scopes).toEqual ['source.python', 'string.quoted.single.single-line.raw-regex.python', 'punctuation.definition.string.end.python']
+    expect(tokens[0][5].value).toBe ' '
+    expect(tokens[0][5].scopes).toEqual ['source.python']
+    expect(tokens[0][6].value).toBe '#'
+    expect(tokens[0][6].scopes).toEqual ['source.python', 'comment.line.number-sign.python', 'punctuation.definition.comment.python']
+    expect(tokens[0][7].value).toBe 'foo'
+    expect(tokens[0][7].scopes).toEqual ['source.python', 'comment.line.number-sign.python']
 
   it "terminates a single-quoted raw string containing opening bracket at closing quote", ->
-    tokens = grammar.tokenizeLines("r'[' #foo")
+    tokens = grammar.tokenizeLines("r'%d[' #foo")
 
     expect(tokens[0][0].value).toBe 'r'
     expect(tokens[0][0].scopes).toEqual ['source.python', 'string.quoted.single.single-line.raw-regex.python', 'storage.type.string.python']
     expect(tokens[0][1].value).toBe "'"
     expect(tokens[0][1].scopes).toEqual ['source.python', 'string.quoted.single.single-line.raw-regex.python', 'punctuation.definition.string.begin.python']
-    expect(tokens[0][2].value).toBe '['
-    expect(tokens[0][2].scopes).toEqual ['source.python', 'string.quoted.single.single-line.raw-regex.python', 'constant.other.character-class.set.regexp', 'punctuation.definition.character-class.regexp']
-    expect(tokens[0][3].value).toBe "'"
-    expect(tokens[0][3].scopes).toEqual ['source.python', 'string.quoted.single.single-line.raw-regex.python', 'punctuation.definition.string.end.python']
-    expect(tokens[0][4].value).toBe ' '
-    expect(tokens[0][4].scopes).toEqual ['source.python']
-    expect(tokens[0][5].value).toBe '#'
-    expect(tokens[0][5].scopes).toEqual ['source.python', 'comment.line.number-sign.python', 'punctuation.definition.comment.python']
-    expect(tokens[0][6].value).toBe 'foo'
-    expect(tokens[0][6].scopes).toEqual ['source.python', 'comment.line.number-sign.python']
+    expect(tokens[0][2].value).toBe '%d'
+    expect(tokens[0][2].scopes).toEqual ['source.python', 'string.quoted.single.single-line.raw-regex.python', 'constant.other.placeholder.python']
+    expect(tokens[0][3].value).toBe '['
+    expect(tokens[0][3].scopes).toEqual ['source.python', 'string.quoted.single.single-line.raw-regex.python', 'constant.other.character-class.set.regexp', 'punctuation.definition.character-class.regexp']
+    expect(tokens[0][4].value).toBe "'"
+    expect(tokens[0][4].scopes).toEqual ['source.python', 'string.quoted.single.single-line.raw-regex.python', 'punctuation.definition.string.end.python']
+    expect(tokens[0][5].value).toBe ' '
+    expect(tokens[0][5].scopes).toEqual ['source.python']
+    expect(tokens[0][6].value).toBe '#'
+    expect(tokens[0][6].scopes).toEqual ['source.python', 'comment.line.number-sign.python', 'punctuation.definition.comment.python']
+    expect(tokens[0][7].value).toBe 'foo'
+    expect(tokens[0][7].scopes).toEqual ['source.python', 'comment.line.number-sign.python']
 
   it "terminates a double-quoted raw string containing opening parenthesis at closing quote", ->
-    tokens = grammar.tokenizeLines('r"(" #foo')
+    tokens = grammar.tokenizeLines('r"%d(" #foo')
 
     expect(tokens[0][0].value).toBe 'r'
     expect(tokens[0][0].scopes).toEqual ['source.python', 'string.quoted.double.single-line.raw-regex.python', 'storage.type.string.python']
     expect(tokens[0][1].value).toBe '"'
     expect(tokens[0][1].scopes).toEqual ['source.python', 'string.quoted.double.single-line.raw-regex.python', 'punctuation.definition.string.begin.python']
-    expect(tokens[0][2].value).toBe '('
-    expect(tokens[0][2].scopes).toEqual ['source.python', 'string.quoted.double.single-line.raw-regex.python', 'meta.group.regexp', 'punctuation.definition.group.regexp']
-    expect(tokens[0][3].value).toBe '"'
-    expect(tokens[0][3].scopes).toEqual ['source.python', 'string.quoted.double.single-line.raw-regex.python', 'punctuation.definition.string.end.python']
-    expect(tokens[0][4].value).toBe ' '
-    expect(tokens[0][4].scopes).toEqual ['source.python']
-    expect(tokens[0][5].value).toBe '#'
-    expect(tokens[0][5].scopes).toEqual ['source.python', 'comment.line.number-sign.python', 'punctuation.definition.comment.python']
-    expect(tokens[0][6].value).toBe 'foo'
-    expect(tokens[0][6].scopes).toEqual ['source.python', 'comment.line.number-sign.python']
+    expect(tokens[0][2].value).toBe '%d'
+    expect(tokens[0][2].scopes).toEqual ['source.python', 'string.quoted.double.single-line.raw-regex.python', 'constant.other.placeholder.python']
+    expect(tokens[0][3].value).toBe '('
+    expect(tokens[0][3].scopes).toEqual ['source.python', 'string.quoted.double.single-line.raw-regex.python', 'meta.group.regexp', 'punctuation.definition.group.regexp']
+    expect(tokens[0][4].value).toBe '"'
+    expect(tokens[0][4].scopes).toEqual ['source.python', 'string.quoted.double.single-line.raw-regex.python', 'punctuation.definition.string.end.python']
+    expect(tokens[0][5].value).toBe ' '
+    expect(tokens[0][5].scopes).toEqual ['source.python']
+    expect(tokens[0][6].value).toBe '#'
+    expect(tokens[0][6].scopes).toEqual ['source.python', 'comment.line.number-sign.python', 'punctuation.definition.comment.python']
+    expect(tokens[0][7].value).toBe 'foo'
+    expect(tokens[0][7].scopes).toEqual ['source.python', 'comment.line.number-sign.python']
 
   it "terminates a double-quoted raw string containing opening bracket at closing quote", ->
-    tokens = grammar.tokenizeLines('r"[" #foo')
+    tokens = grammar.tokenizeLines('r"%d[" #foo')
 
     expect(tokens[0][0].value).toBe 'r'
     expect(tokens[0][0].scopes).toEqual ['source.python', 'string.quoted.double.single-line.raw-regex.python', 'storage.type.string.python']
     expect(tokens[0][1].value).toBe '"'
     expect(tokens[0][1].scopes).toEqual ['source.python', 'string.quoted.double.single-line.raw-regex.python', 'punctuation.definition.string.begin.python']
-    expect(tokens[0][2].value).toBe '['
-    expect(tokens[0][2].scopes).toEqual ['source.python', 'string.quoted.double.single-line.raw-regex.python', 'constant.other.character-class.set.regexp', 'punctuation.definition.character-class.regexp']
-    expect(tokens[0][3].value).toBe '"'
-    expect(tokens[0][3].scopes).toEqual ['source.python', 'string.quoted.double.single-line.raw-regex.python', 'punctuation.definition.string.end.python']
-    expect(tokens[0][4].value).toBe ' '
-    expect(tokens[0][4].scopes).toEqual ['source.python']
-    expect(tokens[0][5].value).toBe '#'
-    expect(tokens[0][5].scopes).toEqual ['source.python', 'comment.line.number-sign.python', 'punctuation.definition.comment.python']
-    expect(tokens[0][6].value).toBe 'foo'
-    expect(tokens[0][6].scopes).toEqual ['source.python', 'comment.line.number-sign.python']
+    expect(tokens[0][2].value).toBe '%d'
+    expect(tokens[0][2].scopes).toEqual ['source.python', 'string.quoted.double.single-line.raw-regex.python', 'constant.other.placeholder.python']
+    expect(tokens[0][3].value).toBe '['
+    expect(tokens[0][3].scopes).toEqual ['source.python', 'string.quoted.double.single-line.raw-regex.python', 'constant.other.character-class.set.regexp', 'punctuation.definition.character-class.regexp']
+    expect(tokens[0][4].value).toBe '"'
+    expect(tokens[0][4].scopes).toEqual ['source.python', 'string.quoted.double.single-line.raw-regex.python', 'punctuation.definition.string.end.python']
+    expect(tokens[0][5].value).toBe ' '
+    expect(tokens[0][5].scopes).toEqual ['source.python']
+    expect(tokens[0][6].value).toBe '#'
+    expect(tokens[0][6].scopes).toEqual ['source.python', 'comment.line.number-sign.python', 'punctuation.definition.comment.python']
+    expect(tokens[0][7].value).toBe 'foo'
+    expect(tokens[0][7].scopes).toEqual ['source.python', 'comment.line.number-sign.python']
 
   it "terminates a unicode single-quoted raw string containing opening parenthesis at closing quote", ->
-    tokens = grammar.tokenizeLines("ur'(' #foo")
+    tokens = grammar.tokenizeLines("ur'%d(' #foo")
 
     expect(tokens[0][0].value).toBe 'ur'
     expect(tokens[0][0].scopes).toEqual ['source.python', 'string.quoted.single.single-line.unicode-raw-regex.python', 'storage.type.string.python']
     expect(tokens[0][1].value).toBe "'"
     expect(tokens[0][1].scopes).toEqual ['source.python', 'string.quoted.single.single-line.unicode-raw-regex.python', 'punctuation.definition.string.begin.python']
-    expect(tokens[0][2].value).toBe '('
-    expect(tokens[0][2].scopes).toEqual ['source.python', 'string.quoted.single.single-line.unicode-raw-regex.python', 'meta.group.regexp', 'punctuation.definition.group.regexp']
-    expect(tokens[0][3].value).toBe "'"
-    expect(tokens[0][3].scopes).toEqual ['source.python', 'string.quoted.single.single-line.unicode-raw-regex.python', 'punctuation.definition.string.end.python']
-    expect(tokens[0][4].value).toBe ' '
-    expect(tokens[0][4].scopes).toEqual ['source.python']
-    expect(tokens[0][5].value).toBe '#'
-    expect(tokens[0][5].scopes).toEqual ['source.python', 'comment.line.number-sign.python', 'punctuation.definition.comment.python']
-    expect(tokens[0][6].value).toBe 'foo'
-    expect(tokens[0][6].scopes).toEqual ['source.python', 'comment.line.number-sign.python']
+    expect(tokens[0][2].value).toBe '%d'
+    expect(tokens[0][2].scopes).toEqual ['source.python', 'string.quoted.single.single-line.unicode-raw-regex.python', 'constant.other.placeholder.python']
+    expect(tokens[0][3].value).toBe '('
+    expect(tokens[0][3].scopes).toEqual ['source.python', 'string.quoted.single.single-line.unicode-raw-regex.python', 'meta.group.regexp', 'punctuation.definition.group.regexp']
+    expect(tokens[0][4].value).toBe "'"
+    expect(tokens[0][4].scopes).toEqual ['source.python', 'string.quoted.single.single-line.unicode-raw-regex.python', 'punctuation.definition.string.end.python']
+    expect(tokens[0][5].value).toBe ' '
+    expect(tokens[0][5].scopes).toEqual ['source.python']
+    expect(tokens[0][6].value).toBe '#'
+    expect(tokens[0][6].scopes).toEqual ['source.python', 'comment.line.number-sign.python', 'punctuation.definition.comment.python']
+    expect(tokens[0][7].value).toBe 'foo'
+    expect(tokens[0][7].scopes).toEqual ['source.python', 'comment.line.number-sign.python']
 
   it "terminates a unicode single-quoted raw string containing opening bracket at closing quote", ->
-    tokens = grammar.tokenizeLines("ur'[' #foo")
+    tokens = grammar.tokenizeLines("ur'%d[' #foo")
 
     expect(tokens[0][0].value).toBe 'ur'
     expect(tokens[0][0].scopes).toEqual ['source.python', 'string.quoted.single.single-line.unicode-raw-regex.python', 'storage.type.string.python']
     expect(tokens[0][1].value).toBe "'"
     expect(tokens[0][1].scopes).toEqual ['source.python', 'string.quoted.single.single-line.unicode-raw-regex.python', 'punctuation.definition.string.begin.python']
-    expect(tokens[0][2].value).toBe '['
-    expect(tokens[0][2].scopes).toEqual ['source.python', 'string.quoted.single.single-line.unicode-raw-regex.python', 'constant.other.character-class.set.regexp', 'punctuation.definition.character-class.regexp']
-    expect(tokens[0][3].value).toBe "'"
-    expect(tokens[0][3].scopes).toEqual ['source.python', 'string.quoted.single.single-line.unicode-raw-regex.python', 'punctuation.definition.string.end.python']
-    expect(tokens[0][4].value).toBe ' '
-    expect(tokens[0][4].scopes).toEqual ['source.python']
-    expect(tokens[0][5].value).toBe '#'
-    expect(tokens[0][5].scopes).toEqual ['source.python', 'comment.line.number-sign.python', 'punctuation.definition.comment.python']
-    expect(tokens[0][6].value).toBe 'foo'
-    expect(tokens[0][6].scopes).toEqual ['source.python', 'comment.line.number-sign.python']
+    expect(tokens[0][2].value).toBe '%d'
+    expect(tokens[0][2].scopes).toEqual ['source.python', 'string.quoted.single.single-line.unicode-raw-regex.python', 'constant.other.placeholder.python']
+    expect(tokens[0][3].value).toBe '['
+    expect(tokens[0][3].scopes).toEqual ['source.python', 'string.quoted.single.single-line.unicode-raw-regex.python', 'constant.other.character-class.set.regexp', 'punctuation.definition.character-class.regexp']
+    expect(tokens[0][4].value).toBe "'"
+    expect(tokens[0][4].scopes).toEqual ['source.python', 'string.quoted.single.single-line.unicode-raw-regex.python', 'punctuation.definition.string.end.python']
+    expect(tokens[0][5].value).toBe ' '
+    expect(tokens[0][5].scopes).toEqual ['source.python']
+    expect(tokens[0][6].value).toBe '#'
+    expect(tokens[0][6].scopes).toEqual ['source.python', 'comment.line.number-sign.python', 'punctuation.definition.comment.python']
+    expect(tokens[0][7].value).toBe 'foo'
+    expect(tokens[0][7].scopes).toEqual ['source.python', 'comment.line.number-sign.python']
 
   it "terminates a unicode double-quoted raw string containing opening parenthesis at closing quote", ->
-    tokens = grammar.tokenizeLines('ur"(" #foo')
+    tokens = grammar.tokenizeLines('ur"%d(" #foo')
 
     expect(tokens[0][0].value).toBe 'ur'
     expect(tokens[0][0].scopes).toEqual ['source.python', 'string.quoted.double.single-line.unicode-raw-regex.python', 'storage.type.string.python']
     expect(tokens[0][1].value).toBe '"'
     expect(tokens[0][1].scopes).toEqual ['source.python', 'string.quoted.double.single-line.unicode-raw-regex.python', 'punctuation.definition.string.begin.python']
-    expect(tokens[0][2].value).toBe '('
-    expect(tokens[0][2].scopes).toEqual ['source.python', 'string.quoted.double.single-line.unicode-raw-regex.python', 'meta.group.regexp', 'punctuation.definition.group.regexp']
-    expect(tokens[0][3].value).toBe '"'
-    expect(tokens[0][3].scopes).toEqual ['source.python', 'string.quoted.double.single-line.unicode-raw-regex.python', 'punctuation.definition.string.end.python']
-    expect(tokens[0][4].value).toBe ' '
-    expect(tokens[0][4].scopes).toEqual ['source.python']
-    expect(tokens[0][5].value).toBe '#'
-    expect(tokens[0][5].scopes).toEqual ['source.python', 'comment.line.number-sign.python', 'punctuation.definition.comment.python']
-    expect(tokens[0][6].value).toBe 'foo'
-    expect(tokens[0][6].scopes).toEqual ['source.python', 'comment.line.number-sign.python']
+    expect(tokens[0][2].value).toBe '%d'
+    expect(tokens[0][2].scopes).toEqual ['source.python', 'string.quoted.double.single-line.unicode-raw-regex.python', 'constant.other.placeholder.python']
+    expect(tokens[0][3].value).toBe '('
+    expect(tokens[0][3].scopes).toEqual ['source.python', 'string.quoted.double.single-line.unicode-raw-regex.python', 'meta.group.regexp', 'punctuation.definition.group.regexp']
+    expect(tokens[0][4].value).toBe '"'
+    expect(tokens[0][4].scopes).toEqual ['source.python', 'string.quoted.double.single-line.unicode-raw-regex.python', 'punctuation.definition.string.end.python']
+    expect(tokens[0][5].value).toBe ' '
+    expect(tokens[0][5].scopes).toEqual ['source.python']
+    expect(tokens[0][6].value).toBe '#'
+    expect(tokens[0][6].scopes).toEqual ['source.python', 'comment.line.number-sign.python', 'punctuation.definition.comment.python']
+    expect(tokens[0][7].value).toBe 'foo'
+    expect(tokens[0][7].scopes).toEqual ['source.python', 'comment.line.number-sign.python']
 
   it "terminates a unicode double-quoted raw string containing opening bracket at closing quote", ->
-    tokens = grammar.tokenizeLines('ur"[" #foo')
+    tokens = grammar.tokenizeLines('ur"%d[" #foo')
 
     expect(tokens[0][0].value).toBe 'ur'
     expect(tokens[0][0].scopes).toEqual ['source.python', 'string.quoted.double.single-line.unicode-raw-regex.python', 'storage.type.string.python']
     expect(tokens[0][1].value).toBe '"'
     expect(tokens[0][1].scopes).toEqual ['source.python', 'string.quoted.double.single-line.unicode-raw-regex.python', 'punctuation.definition.string.begin.python']
-    expect(tokens[0][2].value).toBe '['
-    expect(tokens[0][2].scopes).toEqual ['source.python', 'string.quoted.double.single-line.unicode-raw-regex.python', 'constant.other.character-class.set.regexp', 'punctuation.definition.character-class.regexp']
-    expect(tokens[0][3].value).toBe '"'
-    expect(tokens[0][3].scopes).toEqual ['source.python', 'string.quoted.double.single-line.unicode-raw-regex.python', 'punctuation.definition.string.end.python']
-    expect(tokens[0][4].value).toBe ' '
-    expect(tokens[0][4].scopes).toEqual ['source.python']
-    expect(tokens[0][5].value).toBe '#'
-    expect(tokens[0][5].scopes).toEqual ['source.python', 'comment.line.number-sign.python', 'punctuation.definition.comment.python']
-    expect(tokens[0][6].value).toBe 'foo'
-    expect(tokens[0][6].scopes).toEqual ['source.python', 'comment.line.number-sign.python']
+    expect(tokens[0][2].value).toBe '%d'
+    expect(tokens[0][2].scopes).toEqual ['source.python', 'string.quoted.double.single-line.unicode-raw-regex.python', 'constant.other.placeholder.python']
+    expect(tokens[0][3].value).toBe '['
+    expect(tokens[0][3].scopes).toEqual ['source.python', 'string.quoted.double.single-line.unicode-raw-regex.python', 'constant.other.character-class.set.regexp', 'punctuation.definition.character-class.regexp']
+    expect(tokens[0][4].value).toBe '"'
+    expect(tokens[0][4].scopes).toEqual ['source.python', 'string.quoted.double.single-line.unicode-raw-regex.python', 'punctuation.definition.string.end.python']
+    expect(tokens[0][5].value).toBe ' '
+    expect(tokens[0][5].scopes).toEqual ['source.python']
+    expect(tokens[0][6].value).toBe '#'
+    expect(tokens[0][6].scopes).toEqual ['source.python', 'comment.line.number-sign.python', 'punctuation.definition.comment.python']
+    expect(tokens[0][7].value).toBe 'foo'
+    expect(tokens[0][7].scopes).toEqual ['source.python', 'comment.line.number-sign.python']


### PR DESCRIPTION
Strings like `r'['` and `r'('` were causing the rest of the document to be parsed as if it were inside the regex. Now we terminate the regex at the closing quote in all cases.

This is a backport of https://github.com/textmate/python.tmbundle/commit/2567262452b389f7042ef3026e0443f6336d1735

/cc @vmg
