### PR TITLE
Python syntax also for Snakefile (=Snakemake files)

### DIFF
--- a/grammars/python.cson
+++ b/grammars/python.cson
@@ -11,6 +11,7 @@
   'SConstruct'
   'Sconstruct'
   'sconstruct'
+  'Snakefile'
   'wsgi'
 ]
 'firstLineMatch': '^#!/.*\\bpython\\b'


### PR DESCRIPTION
Files 'Snakefile' should be open with Python highlighting. These files are used by Snakemake (https://bitbucket.org/johanneskoester/snakemake), a Make-like build software which uses Python syntax. It is now very popular for writing bioinformatics pipelines.
