### PR TITLE
Add highlighting for a Python console session or doctest with ">>>" and "..." at beginning of lines

### DIFF
--- a/grammars/python-console.cson
+++ b/grammars/python-console.cson
@@ -1,0 +1,17 @@
+'scopeName': 'text.python.console'
+'name': 'Python Console'
+'fileTypes': [
+  'pycon'
+]
+'patterns': [
+  {
+    'match': '^(>{3}|\\.{3}|In \\[\\d+\\]:) (.+)$'
+    'captures':
+      '1':
+        'name': 'punctuation.separator.prompt.python-session'
+      '2':
+        'patterns': [
+          'include': 'source.python'
+        ]
+  }
+]


### PR DESCRIPTION
Grammar for Python console (`pycon` lexer in Pygments) and doctest.

This is basically Python code that has `>>>` or `...` at the beginning of lines.

Refs: https://github.com/github/linguist/issues/1939

Cc: @aroben 