### PR TITLE
Make python-console handle doctest filetype too

### DIFF
--- a/grammars/python-console.cson
+++ b/grammars/python-console.cson
@@ -1,7 +1,8 @@
 'scopeName': 'text.python.console'
 'name': 'Python Console'
 'fileTypes': [
-  'pycon'
+  'pycon',
+  'doctest'
 ]
 'patterns': [
   {


### PR DESCRIPTION
This is commonly used in docs as well.

E.g.:
https://github.com/hynek/characteristic/pull/26#issuecomment-69324256