### PR TITLE
Excluding the "RPY" extension.

### DIFF
--- a/grammars/python.cson
+++ b/grammars/python.cson
@@ -7,7 +7,6 @@
   'kv'
   'py'
   'pyw'
-  'rpy'
   'SConscript'
   'SConstruct'
   'Sconstruct'


### PR DESCRIPTION
I noticed that not much use scripts with the extension "RPY" and I'm doing a package from that to support the extension "RPY" used in Ren'Py engine.
In this way the files ".rpy" may be identified as Ren'Py files automatically. Is up to you to delete or not, but I thank you now!
>Translated by Google Translate.