### PR TITLE
Add support for version numbers in the first line for python

### DIFF
--- a/grammars/python.cson
+++ b/grammars/python.cson
@@ -16,7 +16,7 @@
   'tac'
   'wsgi'
 ]
-'firstLineMatch': '^#!/.*\\bpython\\b'
+'firstLineMatch': '^#!/.*\\bpython[\\d\\.]*\\b'
 'patterns': [
   {
     'begin': '(^[ \\t]+)?(?=#)'


### PR DESCRIPTION
As I have multiple versions of python installed on my system, I generally like to specify the version of python in my shebang lines. However, atom does not detect these files as python when they don't have the `.py` file extension. I have modified the first line regex to match numbers and dots immediately following the word "python".

The following will now match in addition to all other matched lines:

```python
#!/usr/bin/python3
#!/usr/bin/env python3
#!/usr/bin/env python3.4
```