### PR TITLE
Ensure soft tabs is used by default

### DIFF
--- a/settings/language-python.cson
+++ b/settings/language-python.cson
@@ -1,6 +1,7 @@
 '.source.python':
   'editor':
     'autoIndentOnPaste': false
+    'softTabs': true
     'tabLength': 4
     'foldEndPattern': '^\\s*"""\\s*$'
     'commentStart': '# '


### PR DESCRIPTION
PEP8 clearly states that 4 spaces should be used for indentation, and this
change ensures that regardless of whether the user has configured hard tabs
as their global default.

Refs #62