### PR TITLE
Fix 77: Correctly tokenize 'self.foo'.

### DIFF
--- a/grammars/python.cson
+++ b/grammars/python.cson
@@ -535,9 +535,6 @@
     'include': '#line_continuation'
   }
   {
-    'include': '#language_variables'
-  }
-  {
     'match': '\\b(None|True|False|Ellipsis|NotImplemented)\\b'
     'name': 'constant.language.python'
   }
@@ -549,6 +546,9 @@
   }
   {
     'include': '#dotted_name'
+  }
+  {
+    'include': '#language_variables'
   }
   {
     'begin': '(\\()'

--- a/spec/python-spec.coffee
+++ b/spec/python-spec.coffee
@@ -225,3 +225,23 @@ describe "Python grammar", ->
     expect(tokens[0][11].scopes).toEqual ['source.python', 'meta.structure.list.python', 'meta.structure.list.item.python', 'meta.item-access.python', 'punctuation.definition.arguments.end.python']
     expect(tokens[0][12].value).toBe ']'
     expect(tokens[0][12].scopes).toEqual ['source.python', 'meta.structure.list.python', 'punctuation.definition.list.end.python']
+
+  it "tokenizes properties of self as variables", ->
+    tokens = grammar.tokenizeLines('self.foo')
+    expect(tokens[0].length).toBe 3
+    expect(tokens[0][0].value).toBe 'self'
+    expect(tokens[0][0].scopes).toEqual ['source.python', 'variable.language.python']
+    expect(tokens[0][1].value).toBe '.'
+    expect(tokens[0][1].scopes).toEqual ['source.python']
+    expect(tokens[0][2].value).toBe 'foo'
+    expect(tokens[0][2].scopes).toEqual ['source.python']
+
+  it "tokenizes properties of a variable as variables", ->
+    tokens = grammar.tokenizeLines('bar.foo')
+    expect(tokens[0].length).toBe 3
+    expect(tokens[0][0].value).toBe 'bar'
+    expect(tokens[0][0].scopes).toEqual ['source.python']
+    expect(tokens[0][1].value).toBe '.'
+    expect(tokens[0][1].scopes).toEqual ['source.python']
+    expect(tokens[0][2].value).toBe 'foo'
+    expect(tokens[0][2].scopes).toEqual ['source.python']


### PR DESCRIPTION
This fixes #77.  The issue is that the language_variables rule was before the dotted_name rule, so it took precedence.  Thus, when the grammar tried to parse `'self.foo'`, it parsed `'self'` alone, leaving it to parse `'.foo'`, which it did strangely as `['.', 'f', 'oo']`.  Now it tries to parse it as a dotted_name first, which handles that case correctly.  This PR also includes two relevant specs.