### PR TITLE
Support return value annotations in functions

### DIFF
--- a/grammars/python.cson
+++ b/grammars/python.cson
@@ -252,14 +252,10 @@
     'beginCaptures':
       '1':
         'name': 'storage.type.function.python'
-    'end': '(\\))\\s*(?:(\\:)|(.*$\\n?))'
+    'end': '\\:'
     'endCaptures':
-      '1':
-        'name': 'punctuation.definition.parameters.end.python'
-      '2':
+      '0':
         'name': 'punctuation.section.function.begin.python'
-      '3':
-        'name': 'invalid.illegal.missing-section-begin.python'
     'name': 'meta.function.python'
     'patterns': [
       {
@@ -273,12 +269,12 @@
         ]
       }
       {
-        'begin': '(\\()'
+        'begin': '\\('
         'beginCaptures':
-          '1':
+          '0':
             'name': 'punctuation.definition.parameters.begin.python'
         'contentName': 'meta.function.parameters.python'
-        'end': '(?=\\)\\s*\\:)'
+        'end': '\\)'
         'patterns': [
           {
             'include': '#keyword_arguments'


### PR DESCRIPTION
This pull request adds support for return value annotations in functions (as requested in #68) and fixes an error reported in #86.

``` python
def init(self, int = 3) -> None :
        """Construct semantic analyzer.
        """
        self.pyversion = pyversion

def visit_file(self, file_node: MypyFile, fnam: str) -> None:
        self.errors.set_file(fnam)
        self.errors.set_ignored_lines(file_node.ignored_lines)
        self.cur_mod_node = file_node
```

See the [fix in Lightshow](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_url=https%3A%2F%2Fraw.githubusercontent.com%2Fpchaigno%2Flanguage-python%2F02d464d2bd5d6185d0af4c5db7e2467dbdcad5c6%2Fgrammars%2Fpython.cson&grammar_text=&code_source=from-text&code_url=&code=def+init%28self%2C+int+%3D+3%29+-%3E+None+%3A%0D%0A++++++++%22%22%22Construct+semantic+analyzer.%0D%0A++++++++%22%22%22%0D%0A++++++++self.pyversion+%3D+pyversion%0D%0A%0D%0Adef+visit_file%28self%2C+file_node%3A+MypyFile%2C+fnam%3A+str%29+-%3E+None%3A%0D%0A++++++++self.errors.set_file%28fnam%29%0D%0A++++++++self.errors.set_ignored_lines%28file_node.ignored_lines%29%0D%0A++++++++self.cur_mod_node+%3D+file_node).

It loses the `invalid.illegal` scope for function headers without a terminating `:`. I couldn't find a way to keep it. Though, most of the time, [you can still clearly see that it's missing](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_url=https%3A%2F%2Fraw.githubusercontent.com%2Fpchaigno%2Flanguage-python%2F02d464d2bd5d6185d0af4c5db7e2467dbdcad5c6%2Fgrammars%2Fpython.cson&grammar_text=&code_source=from-text&code_url=&code=def+init%28self%2C+int+%3D+3%29+-%3E+None%0D%0A++++++++%22%22%22Construct+semantic+analyzer.%0D%0A++++++++%22%22%22%0D%0A++++++++self.pyversion+%3D+pyversion%0D%0A%0D%0Adef+visit_file%28self%2C+file_node%3A+MypyFile%2C+fnam%3A+str%29+-%3E+None%3A%0D%0A++++++++self.errors.set_file%28fnam%29%0D%0A++++++++self.errors.set_ignored_lines%28file_node.ignored_lines%29%0D%0A++++++++self.cur_mod_node+%3D+file_node).
