### PR TITLE
Line comments in function arguments

### DIFF
--- a/grammars/python.cson
+++ b/grammars/python.cson
@@ -19,21 +19,7 @@
 'firstLineMatch': '^#!/.*\\bpython[\\d\\.]*\\b'
 'patterns': [
   {
-    'begin': '(^[ \\t]+)?(?=#)'
-    'beginCaptures':
-      '1':
-        'name': 'punctuation.whitespace.comment.leading.python'
-    'end': '(?!\\G)'
-    'patterns': [
-      {
-        'begin': '#'
-        'beginCaptures':
-          '0':
-            'name': 'punctuation.definition.comment.python'
-        'end': '\\n'
-        'name': 'comment.line.number-sign.python'
-      }
-    ]
+    'include': '#line_comments'
   }
   {
     'match': '\\b(?i:(0x\\h*)L)'
@@ -691,6 +677,22 @@
             'include': '#string_quoted_single'
           }
         ]
+      }
+    ]
+  'line_comments':
+    'begin': '(^[ \\t]+)?(?=#)'
+    'beginCaptures':
+      '1':
+        'name': 'punctuation.whitespace.comment.leading.python'
+    'end': '(?!\\G)'
+    'patterns': [
+      {
+        'begin': '#'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.comment.python'
+        'end': '\\n'
+        'name': 'comment.line.number-sign.python'
       }
     ]
   'dotted_name':

--- a/grammars/python.cson
+++ b/grammars/python.cson
@@ -267,6 +267,9 @@
         'end': '(?=\\)\\s*\\:)'
         'patterns': [
           {
+            'include': '#line_comments'
+          }
+          {
             'include': '#keyword_arguments'
           }
           {

--- a/spec/python-spec.coffee
+++ b/spec/python-spec.coffee
@@ -247,19 +247,33 @@ describe "Python grammar", ->
     expect(tokens[0][2].scopes).toEqual ['source.python']
 
   it "tokenizes comments inside function parameters", ->
-    tokens = grammar.tokenizeLines('def test(arg, # comment')
-    expect(tokens[0].length).toBe 10
-    expect(tokens[0][0].value).toBe 'def'
-    expect(tokens[0][0].scopes).toEqual ['source.python', 'meta.function.python', 'storage.type.function.python']
-    expect(tokens[0][2].value).toBe 'test'
-    expect(tokens[0][2].scopes).toEqual ['source.python', 'meta.function.python', 'entity.name.function.python']
-    expect(tokens[0][3].value).toBe '('
-    expect(tokens[0][3].scopes).toEqual ['source.python', 'meta.function.python', 'punctuation.definition.parameters.begin.python']
-    expect(tokens[0][4].value).toBe 'arg'
-    expect(tokens[0][4].scopes).toEqual ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'variable.parameter.function.python']
-    expect(tokens[0][5].value).toBe ','
-    expect(tokens[0][5].scopes).toEqual ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'punctuation.separator.parameters.python']
-    expect(tokens[0][7].value).toBe '#'
-    expect(tokens[0][7].scopes).toEqual ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'comment.line.number-sign.python', 'punctuation.definition.comment.python']
-    expect(tokens[0][8].value).toBe ' comment'
-    expect(tokens[0][8].scopes).toEqual ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'comment.line.number-sign.python']
+    {tokens} = grammar.tokenizeLine('def test(arg, # comment')
+    expect(tokens.length).toBe 10
+    expect(tokens[0]).toEqual value: 'def', scopes: ['source.python', 'meta.function.python', 'storage.type.function.python']
+    expect(tokens[2]).toEqual value: 'test', scopes: ['source.python', 'meta.function.python', 'entity.name.function.python']
+    expect(tokens[3]).toEqual value: '(', scopes: ['source.python', 'meta.function.python', 'punctuation.definition.parameters.begin.python']
+    expect(tokens[4]).toEqual value: 'arg', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'variable.parameter.function.python']
+    expect(tokens[5]).toEqual value: ',', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'punctuation.separator.parameters.python']
+    expect(tokens[7]).toEqual value: '#', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'comment.line.number-sign.python', 'punctuation.definition.comment.python']
+    expect(tokens[8]).toEqual value: ' comment', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'comment.line.number-sign.python']
+
+    tokens = grammar.tokenizeLines("""
+      def __init__(
+        self,
+        codec, # comment
+        config
+      ):
+    """)
+    expect(tokens[0][0]).toEqual value: 'def', scopes: ['source.python', 'meta.function.python', 'storage.type.function.python']
+    expect(tokens[0][2]).toEqual value: '__init__', scopes: ['source.python', 'meta.function.python', 'entity.name.function.python', 'support.function.magic.python']
+    expect(tokens[0][3]).toEqual value: '(', scopes: ['source.python', 'meta.function.python', 'punctuation.definition.parameters.begin.python']
+    expect(tokens[1][1]).toEqual value: 'self', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'variable.parameter.function.python']
+    expect(tokens[1][2]).toEqual value: ',', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'punctuation.separator.parameters.python']
+    expect(tokens[2][1]).toEqual value: 'codec', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'variable.parameter.function.python']
+    expect(tokens[2][2]).toEqual value: ',', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'punctuation.separator.parameters.python']
+    expect(tokens[2][4]).toEqual value: '#', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'comment.line.number-sign.python', 'punctuation.definition.comment.python']
+    expect(tokens[2][5]).toEqual value: ' comment', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'comment.line.number-sign.python']
+    expect(tokens[3][1]).toEqual value: 'config', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'variable.parameter.function.python']
+    expect(tokens[4][0]).toEqual value: ')', scopes: ['source.python', 'meta.function.python', 'punctuation.definition.parameters.end.python']
+    expect(tokens[4][1]).toEqual value: ':', scopes: ['source.python', 'meta.function.python', 'punctuation.section.function.begin.python']
+

--- a/spec/python-spec.coffee
+++ b/spec/python-spec.coffee
@@ -245,3 +245,21 @@ describe "Python grammar", ->
     expect(tokens[0][1].scopes).toEqual ['source.python']
     expect(tokens[0][2].value).toBe 'foo'
     expect(tokens[0][2].scopes).toEqual ['source.python']
+
+  it "tokenizes comments inside function parameters", ->
+    tokens = grammar.tokenizeLines('def test(arg, # comment')
+    expect(tokens[0].length).toBe 10
+    expect(tokens[0][0].value).toBe 'def'
+    expect(tokens[0][0].scopes).toEqual ['source.python', 'meta.function.python', 'storage.type.function.python']
+    expect(tokens[0][2].value).toBe 'test'
+    expect(tokens[0][2].scopes).toEqual ['source.python', 'meta.function.python', 'entity.name.function.python']
+    expect(tokens[0][3].value).toBe '('
+    expect(tokens[0][3].scopes).toEqual ['source.python', 'meta.function.python', 'punctuation.definition.parameters.begin.python']
+    expect(tokens[0][4].value).toBe 'arg'
+    expect(tokens[0][4].scopes).toEqual ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'variable.parameter.function.python']
+    expect(tokens[0][5].value).toBe ','
+    expect(tokens[0][5].scopes).toEqual ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'punctuation.separator.parameters.python']
+    expect(tokens[0][7].value).toBe '#'
+    expect(tokens[0][7].scopes).toEqual ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'comment.line.number-sign.python', 'punctuation.definition.comment.python']
+    expect(tokens[0][8].value).toBe ' comment'
+    expect(tokens[0][8].scopes).toEqual ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'comment.line.number-sign.python']

--- a/spec/python-spec.coffee
+++ b/spec/python-spec.coffee
@@ -228,7 +228,7 @@ describe "Python grammar", ->
 
   it "tokenizes properties of self as variables", ->
     tokens = grammar.tokenizeLines('self.foo')
-    expect(tokens[0].length).toBe 3
+
     expect(tokens[0][0].value).toBe 'self'
     expect(tokens[0][0].scopes).toEqual ['source.python', 'variable.language.python']
     expect(tokens[0][1].value).toBe '.'
@@ -238,7 +238,7 @@ describe "Python grammar", ->
 
   it "tokenizes properties of a variable as variables", ->
     tokens = grammar.tokenizeLines('bar.foo')
-    expect(tokens[0].length).toBe 3
+
     expect(tokens[0][0].value).toBe 'bar'
     expect(tokens[0][0].scopes).toEqual ['source.python']
     expect(tokens[0][1].value).toBe '.'
@@ -248,7 +248,7 @@ describe "Python grammar", ->
 
   it "tokenizes comments inside function parameters", ->
     {tokens} = grammar.tokenizeLine('def test(arg, # comment')
-    expect(tokens.length).toBe 10
+
     expect(tokens[0]).toEqual value: 'def', scopes: ['source.python', 'meta.function.python', 'storage.type.function.python']
     expect(tokens[2]).toEqual value: 'test', scopes: ['source.python', 'meta.function.python', 'entity.name.function.python']
     expect(tokens[3]).toEqual value: '(', scopes: ['source.python', 'meta.function.python', 'punctuation.definition.parameters.begin.python']
@@ -264,6 +264,7 @@ describe "Python grammar", ->
         config
       ):
     """)
+
     expect(tokens[0][0]).toEqual value: 'def', scopes: ['source.python', 'meta.function.python', 'storage.type.function.python']
     expect(tokens[0][2]).toEqual value: '__init__', scopes: ['source.python', 'meta.function.python', 'entity.name.function.python', 'support.function.magic.python']
     expect(tokens[0][3]).toEqual value: '(', scopes: ['source.python', 'meta.function.python', 'punctuation.definition.parameters.begin.python']


### PR DESCRIPTION
This pull request fixes an issue reported in #81:
```python
def __init__(
    self,
    container,
    group,
    codec=0,  # requests small enough that compression would be unnecessary overhead
    **config
):
```
See the [fix in Lightshow](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_url=https%3A%2F%2Fraw.githubusercontent.com%2Fpchaigno%2Flanguage-python%2Fdeb68c308c6e3a1f49dbc295d50b5d7b61581206%2Fgrammars%2Fpython.cson&grammar_text=&code_source=from-text&code_url=&code=def+__init__%28%0D%0A++++self%2C%0D%0A++++container%2C%0D%0A++++group%2C%0D%0A++++codec%3D0%2C++%23+requests+small+enough+that+compression+would+be+unnecessary+overhead%0D%0A++++**config%0D%0A%29%3A).