### PR TITLE
Combine and improve specs

### DIFF
--- a/spec/python-spec.coffee
+++ b/spec/python-spec.coffee
@@ -13,238 +13,115 @@ describe "Python grammar", ->
     expect(grammar.scopeName).toBe "source.python"
 
   it "tokenizes multi-line strings", ->
-    tokens = grammar.tokenizeLines('"1\\\n2"')
+    tokens = grammar.tokenizeLines '''
+      "1\\
+      2"
+    '''
 
-    # Line 0
-    expect(tokens[0][0].value).toBe '"'
-    expect(tokens[0][0].scopes).toEqual ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.begin.python']
+    expect(tokens[0][0]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.begin.python']
+    expect(tokens[0][1]).toEqual value: '1', scopes: ['source.python', 'string.quoted.double.single-line.python']
+    expect(tokens[0][2]).toEqual value: '\\', scopes: ['source.python', 'string.quoted.double.single-line.python', 'constant.character.escape.newline.python']
+    expect(tokens[1][0]).toEqual value: '2', scopes: ['source.python', 'string.quoted.double.single-line.python']
+    expect(tokens[1][1]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.end.python']
 
-    expect(tokens[0][1].value).toBe '1'
-    expect(tokens[0][1].scopes).toEqual ['source.python', 'string.quoted.double.single-line.python']
+  it "terminates a raw string containing opening parenthesis at closing quote", ->
+    delimsByScope =
+      "string.quoted.single.single-line.raw-regex.python": "'"
+      "string.quoted.double.single-line.raw-regex.python": '"'
 
-    expect(tokens[0][2].value).toBe '\\'
-    expect(tokens[0][2].scopes).toEqual ['source.python', 'string.quoted.double.single-line.python', 'constant.character.escape.newline.python']
+    for scope, delim of delimsByScope
+      {tokens} = grammar.tokenizeLine("r" + delim + "%d(" + delim + " #foo")
 
-    expect(tokens[0][3]).not.toBeDefined()
+      expect(tokens[0]).toEqual value: 'r', scopes: ['source.python', scope, 'storage.type.string.python']
+      expect(tokens[1]).toEqual value: delim, scopes: ['source.python', scope, 'punctuation.definition.string.begin.python']
+      expect(tokens[2]).toEqual value: '%d', scopes: ['source.python', scope, 'constant.other.placeholder.python']
+      expect(tokens[3]).toEqual value: '(', scopes: ['source.python', scope, 'meta.group.regexp', 'punctuation.definition.group.regexp']
+      expect(tokens[4]).toEqual value: delim, scopes: ['source.python', scope, 'punctuation.definition.string.end.python']
+      expect(tokens[5]).toEqual value: ' ', scopes: ['source.python']
+      expect(tokens[6]).toEqual value: '#', scopes: ['source.python', 'comment.line.number-sign.python', 'punctuation.definition.comment.python']
+      expect(tokens[7]).toEqual value: 'foo', scopes: ['source.python', 'comment.line.number-sign.python']
 
-    # Line 1
-    expect(tokens[1][0].value).toBe '2'
-    expect(tokens[1][0].scopes).toEqual ['source.python', 'string.quoted.double.single-line.python']
+  it "terminates a raw string containing opening bracket at closing quote", ->
+    delimsByScope =
+      "string.quoted.single.single-line.raw-regex.python": "'"
+      "string.quoted.double.single-line.raw-regex.python": '"'
 
-    expect(tokens[1][1].value).toBe '"'
-    expect(tokens[1][1].scopes).toEqual ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.end.python']
+    for scope, delim of delimsByScope
+      {tokens} = grammar.tokenizeLine("r" + delim + "%d[" + delim + " #foo")
 
-    expect(tokens[1][2]).not.toBeDefined()
+      expect(tokens[0]).toEqual value: 'r', scopes: ['source.python', scope, 'storage.type.string.python']
+      expect(tokens[1]).toEqual value: delim, scopes: ['source.python', scope, 'punctuation.definition.string.begin.python']
+      expect(tokens[2]).toEqual value: '%d', scopes: ['source.python', scope, 'constant.other.placeholder.python']
+      expect(tokens[3]).toEqual value: '[', scopes: ['source.python', scope, 'constant.other.character-class.set.regexp', 'punctuation.definition.character-class.regexp']
+      expect(tokens[4]).toEqual value: delim, scopes: ['source.python', scope, 'punctuation.definition.string.end.python']
+      expect(tokens[5]).toEqual value: ' ', scopes: ['source.python']
+      expect(tokens[6]).toEqual value: '#', scopes: ['source.python', 'comment.line.number-sign.python', 'punctuation.definition.comment.python']
+      expect(tokens[7]).toEqual value: 'foo', scopes: ['source.python', 'comment.line.number-sign.python']
 
-  it "terminates a single-quoted raw string containing opening parenthesis at closing quote", ->
-    tokens = grammar.tokenizeLines("r'%d(' #foo")
+  it "terminates a unicode raw string containing opening parenthesis at closing quote", ->
+    delimsByScope =
+      "string.quoted.single.single-line.unicode-raw-regex.python": "'"
+      "string.quoted.double.single-line.unicode-raw-regex.python": '"'
 
-    expect(tokens[0][0].value).toBe 'r'
-    expect(tokens[0][0].scopes).toEqual ['source.python', 'string.quoted.single.single-line.raw-regex.python', 'storage.type.string.python']
-    expect(tokens[0][1].value).toBe "'"
-    expect(tokens[0][1].scopes).toEqual ['source.python', 'string.quoted.single.single-line.raw-regex.python', 'punctuation.definition.string.begin.python']
-    expect(tokens[0][2].value).toBe '%d'
-    expect(tokens[0][2].scopes).toEqual ['source.python', 'string.quoted.single.single-line.raw-regex.python', 'constant.other.placeholder.python']
-    expect(tokens[0][3].value).toBe '('
-    expect(tokens[0][3].scopes).toEqual ['source.python', 'string.quoted.single.single-line.raw-regex.python', 'meta.group.regexp', 'punctuation.definition.group.regexp']
-    expect(tokens[0][4].value).toBe "'"
-    expect(tokens[0][4].scopes).toEqual ['source.python', 'string.quoted.single.single-line.raw-regex.python', 'punctuation.definition.string.end.python']
-    expect(tokens[0][5].value).toBe ' '
-    expect(tokens[0][5].scopes).toEqual ['source.python']
-    expect(tokens[0][6].value).toBe '#'
-    expect(tokens[0][6].scopes).toEqual ['source.python', 'comment.line.number-sign.python', 'punctuation.definition.comment.python']
-    expect(tokens[0][7].value).toBe 'foo'
-    expect(tokens[0][7].scopes).toEqual ['source.python', 'comment.line.number-sign.python']
+    for scope, delim of delimsByScope
+      {tokens} = grammar.tokenizeLine("ur" + delim + "%d(" + delim + " #foo")
 
-  it "terminates a single-quoted raw string containing opening bracket at closing quote", ->
-    tokens = grammar.tokenizeLines("r'%d[' #foo")
+      expect(tokens[0]).toEqual value: 'ur', scopes: ['source.python', scope, 'storage.type.string.python']
+      expect(tokens[1]).toEqual value: delim, scopes: ['source.python', scope, 'punctuation.definition.string.begin.python']
+      expect(tokens[2]).toEqual value: '%d', scopes: ['source.python', scope, 'constant.other.placeholder.python']
+      expect(tokens[3]).toEqual value: '(', scopes: ['source.python', scope, 'meta.group.regexp', 'punctuation.definition.group.regexp']
+      expect(tokens[4]).toEqual value: delim, scopes: ['source.python', scope, 'punctuation.definition.string.end.python']
+      expect(tokens[5]).toEqual value: ' ', scopes: ['source.python']
+      expect(tokens[6]).toEqual value: '#', scopes: ['source.python', 'comment.line.number-sign.python', 'punctuation.definition.comment.python']
+      expect(tokens[7]).toEqual value: 'foo', scopes: ['source.python', 'comment.line.number-sign.python']
 
-    expect(tokens[0][0].value).toBe 'r'
-    expect(tokens[0][0].scopes).toEqual ['source.python', 'string.quoted.single.single-line.raw-regex.python', 'storage.type.string.python']
-    expect(tokens[0][1].value).toBe "'"
-    expect(tokens[0][1].scopes).toEqual ['source.python', 'string.quoted.single.single-line.raw-regex.python', 'punctuation.definition.string.begin.python']
-    expect(tokens[0][2].value).toBe '%d'
-    expect(tokens[0][2].scopes).toEqual ['source.python', 'string.quoted.single.single-line.raw-regex.python', 'constant.other.placeholder.python']
-    expect(tokens[0][3].value).toBe '['
-    expect(tokens[0][3].scopes).toEqual ['source.python', 'string.quoted.single.single-line.raw-regex.python', 'constant.other.character-class.set.regexp', 'punctuation.definition.character-class.regexp']
-    expect(tokens[0][4].value).toBe "'"
-    expect(tokens[0][4].scopes).toEqual ['source.python', 'string.quoted.single.single-line.raw-regex.python', 'punctuation.definition.string.end.python']
-    expect(tokens[0][5].value).toBe ' '
-    expect(tokens[0][5].scopes).toEqual ['source.python']
-    expect(tokens[0][6].value).toBe '#'
-    expect(tokens[0][6].scopes).toEqual ['source.python', 'comment.line.number-sign.python', 'punctuation.definition.comment.python']
-    expect(tokens[0][7].value).toBe 'foo'
-    expect(tokens[0][7].scopes).toEqual ['source.python', 'comment.line.number-sign.python']
+  it "terminates a unicode raw string containing opening bracket at closing quote", ->
+    delimsByScope =
+      "string.quoted.single.single-line.unicode-raw-regex.python": "'"
+      "string.quoted.double.single-line.unicode-raw-regex.python": '"'
 
-  it "terminates a double-quoted raw string containing opening parenthesis at closing quote", ->
-    tokens = grammar.tokenizeLines('r"%d(" #foo')
+    for scope, delim of delimsByScope
+      {tokens} = grammar.tokenizeLine("ur" + delim + "%d[" + delim + " #foo")
 
-    expect(tokens[0][0].value).toBe 'r'
-    expect(tokens[0][0].scopes).toEqual ['source.python', 'string.quoted.double.single-line.raw-regex.python', 'storage.type.string.python']
-    expect(tokens[0][1].value).toBe '"'
-    expect(tokens[0][1].scopes).toEqual ['source.python', 'string.quoted.double.single-line.raw-regex.python', 'punctuation.definition.string.begin.python']
-    expect(tokens[0][2].value).toBe '%d'
-    expect(tokens[0][2].scopes).toEqual ['source.python', 'string.quoted.double.single-line.raw-regex.python', 'constant.other.placeholder.python']
-    expect(tokens[0][3].value).toBe '('
-    expect(tokens[0][3].scopes).toEqual ['source.python', 'string.quoted.double.single-line.raw-regex.python', 'meta.group.regexp', 'punctuation.definition.group.regexp']
-    expect(tokens[0][4].value).toBe '"'
-    expect(tokens[0][4].scopes).toEqual ['source.python', 'string.quoted.double.single-line.raw-regex.python', 'punctuation.definition.string.end.python']
-    expect(tokens[0][5].value).toBe ' '
-    expect(tokens[0][5].scopes).toEqual ['source.python']
-    expect(tokens[0][6].value).toBe '#'
-    expect(tokens[0][6].scopes).toEqual ['source.python', 'comment.line.number-sign.python', 'punctuation.definition.comment.python']
-    expect(tokens[0][7].value).toBe 'foo'
-    expect(tokens[0][7].scopes).toEqual ['source.python', 'comment.line.number-sign.python']
-
-  it "terminates a double-quoted raw string containing opening bracket at closing quote", ->
-    tokens = grammar.tokenizeLines('r"%d[" #foo')
-
-    expect(tokens[0][0].value).toBe 'r'
-    expect(tokens[0][0].scopes).toEqual ['source.python', 'string.quoted.double.single-line.raw-regex.python', 'storage.type.string.python']
-    expect(tokens[0][1].value).toBe '"'
-    expect(tokens[0][1].scopes).toEqual ['source.python', 'string.quoted.double.single-line.raw-regex.python', 'punctuation.definition.string.begin.python']
-    expect(tokens[0][2].value).toBe '%d'
-    expect(tokens[0][2].scopes).toEqual ['source.python', 'string.quoted.double.single-line.raw-regex.python', 'constant.other.placeholder.python']
-    expect(tokens[0][3].value).toBe '['
-    expect(tokens[0][3].scopes).toEqual ['source.python', 'string.quoted.double.single-line.raw-regex.python', 'constant.other.character-class.set.regexp', 'punctuation.definition.character-class.regexp']
-    expect(tokens[0][4].value).toBe '"'
-    expect(tokens[0][4].scopes).toEqual ['source.python', 'string.quoted.double.single-line.raw-regex.python', 'punctuation.definition.string.end.python']
-    expect(tokens[0][5].value).toBe ' '
-    expect(tokens[0][5].scopes).toEqual ['source.python']
-    expect(tokens[0][6].value).toBe '#'
-    expect(tokens[0][6].scopes).toEqual ['source.python', 'comment.line.number-sign.python', 'punctuation.definition.comment.python']
-    expect(tokens[0][7].value).toBe 'foo'
-    expect(tokens[0][7].scopes).toEqual ['source.python', 'comment.line.number-sign.python']
-
-  it "terminates a unicode single-quoted raw string containing opening parenthesis at closing quote", ->
-    tokens = grammar.tokenizeLines("ur'%d(' #foo")
-
-    expect(tokens[0][0].value).toBe 'ur'
-    expect(tokens[0][0].scopes).toEqual ['source.python', 'string.quoted.single.single-line.unicode-raw-regex.python', 'storage.type.string.python']
-    expect(tokens[0][1].value).toBe "'"
-    expect(tokens[0][1].scopes).toEqual ['source.python', 'string.quoted.single.single-line.unicode-raw-regex.python', 'punctuation.definition.string.begin.python']
-    expect(tokens[0][2].value).toBe '%d'
-    expect(tokens[0][2].scopes).toEqual ['source.python', 'string.quoted.single.single-line.unicode-raw-regex.python', 'constant.other.placeholder.python']
-    expect(tokens[0][3].value).toBe '('
-    expect(tokens[0][3].scopes).toEqual ['source.python', 'string.quoted.single.single-line.unicode-raw-regex.python', 'meta.group.regexp', 'punctuation.definition.group.regexp']
-    expect(tokens[0][4].value).toBe "'"
-    expect(tokens[0][4].scopes).toEqual ['source.python', 'string.quoted.single.single-line.unicode-raw-regex.python', 'punctuation.definition.string.end.python']
-    expect(tokens[0][5].value).toBe ' '
-    expect(tokens[0][5].scopes).toEqual ['source.python']
-    expect(tokens[0][6].value).toBe '#'
-    expect(tokens[0][6].scopes).toEqual ['source.python', 'comment.line.number-sign.python', 'punctuation.definition.comment.python']
-    expect(tokens[0][7].value).toBe 'foo'
-    expect(tokens[0][7].scopes).toEqual ['source.python', 'comment.line.number-sign.python']
-
-  it "terminates a unicode single-quoted raw string containing opening bracket at closing quote", ->
-    tokens = grammar.tokenizeLines("ur'%d[' #foo")
-
-    expect(tokens[0][0].value).toBe 'ur'
-    expect(tokens[0][0].scopes).toEqual ['source.python', 'string.quoted.single.single-line.unicode-raw-regex.python', 'storage.type.string.python']
-    expect(tokens[0][1].value).toBe "'"
-    expect(tokens[0][1].scopes).toEqual ['source.python', 'string.quoted.single.single-line.unicode-raw-regex.python', 'punctuation.definition.string.begin.python']
-    expect(tokens[0][2].value).toBe '%d'
-    expect(tokens[0][2].scopes).toEqual ['source.python', 'string.quoted.single.single-line.unicode-raw-regex.python', 'constant.other.placeholder.python']
-    expect(tokens[0][3].value).toBe '['
-    expect(tokens[0][3].scopes).toEqual ['source.python', 'string.quoted.single.single-line.unicode-raw-regex.python', 'constant.other.character-class.set.regexp', 'punctuation.definition.character-class.regexp']
-    expect(tokens[0][4].value).toBe "'"
-    expect(tokens[0][4].scopes).toEqual ['source.python', 'string.quoted.single.single-line.unicode-raw-regex.python', 'punctuation.definition.string.end.python']
-    expect(tokens[0][5].value).toBe ' '
-    expect(tokens[0][5].scopes).toEqual ['source.python']
-    expect(tokens[0][6].value).toBe '#'
-    expect(tokens[0][6].scopes).toEqual ['source.python', 'comment.line.number-sign.python', 'punctuation.definition.comment.python']
-    expect(tokens[0][7].value).toBe 'foo'
-    expect(tokens[0][7].scopes).toEqual ['source.python', 'comment.line.number-sign.python']
-
-  it "terminates a unicode double-quoted raw string containing opening parenthesis at closing quote", ->
-    tokens = grammar.tokenizeLines('ur"%d(" #foo')
-
-    expect(tokens[0][0].value).toBe 'ur'
-    expect(tokens[0][0].scopes).toEqual ['source.python', 'string.quoted.double.single-line.unicode-raw-regex.python', 'storage.type.string.python']
-    expect(tokens[0][1].value).toBe '"'
-    expect(tokens[0][1].scopes).toEqual ['source.python', 'string.quoted.double.single-line.unicode-raw-regex.python', 'punctuation.definition.string.begin.python']
-    expect(tokens[0][2].value).toBe '%d'
-    expect(tokens[0][2].scopes).toEqual ['source.python', 'string.quoted.double.single-line.unicode-raw-regex.python', 'constant.other.placeholder.python']
-    expect(tokens[0][3].value).toBe '('
-    expect(tokens[0][3].scopes).toEqual ['source.python', 'string.quoted.double.single-line.unicode-raw-regex.python', 'meta.group.regexp', 'punctuation.definition.group.regexp']
-    expect(tokens[0][4].value).toBe '"'
-    expect(tokens[0][4].scopes).toEqual ['source.python', 'string.quoted.double.single-line.unicode-raw-regex.python', 'punctuation.definition.string.end.python']
-    expect(tokens[0][5].value).toBe ' '
-    expect(tokens[0][5].scopes).toEqual ['source.python']
-    expect(tokens[0][6].value).toBe '#'
-    expect(tokens[0][6].scopes).toEqual ['source.python', 'comment.line.number-sign.python', 'punctuation.definition.comment.python']
-    expect(tokens[0][7].value).toBe 'foo'
-    expect(tokens[0][7].scopes).toEqual ['source.python', 'comment.line.number-sign.python']
-
-  it "terminates a unicode double-quoted raw string containing opening bracket at closing quote", ->
-    tokens = grammar.tokenizeLines('ur"%d[" #foo')
-
-    expect(tokens[0][0].value).toBe 'ur'
-    expect(tokens[0][0].scopes).toEqual ['source.python', 'string.quoted.double.single-line.unicode-raw-regex.python', 'storage.type.string.python']
-    expect(tokens[0][1].value).toBe '"'
-    expect(tokens[0][1].scopes).toEqual ['source.python', 'string.quoted.double.single-line.unicode-raw-regex.python', 'punctuation.definition.string.begin.python']
-    expect(tokens[0][2].value).toBe '%d'
-    expect(tokens[0][2].scopes).toEqual ['source.python', 'string.quoted.double.single-line.unicode-raw-regex.python', 'constant.other.placeholder.python']
-    expect(tokens[0][3].value).toBe '['
-    expect(tokens[0][3].scopes).toEqual ['source.python', 'string.quoted.double.single-line.unicode-raw-regex.python', 'constant.other.character-class.set.regexp', 'punctuation.definition.character-class.regexp']
-    expect(tokens[0][4].value).toBe '"'
-    expect(tokens[0][4].scopes).toEqual ['source.python', 'string.quoted.double.single-line.unicode-raw-regex.python', 'punctuation.definition.string.end.python']
-    expect(tokens[0][5].value).toBe ' '
-    expect(tokens[0][5].scopes).toEqual ['source.python']
-    expect(tokens[0][6].value).toBe '#'
-    expect(tokens[0][6].scopes).toEqual ['source.python', 'comment.line.number-sign.python', 'punctuation.definition.comment.python']
-    expect(tokens[0][7].value).toBe 'foo'
-    expect(tokens[0][7].scopes).toEqual ['source.python', 'comment.line.number-sign.python']
+      expect(tokens[0]).toEqual value: 'ur', scopes: ['source.python', scope, 'storage.type.string.python']
+      expect(tokens[1]).toEqual value: delim, scopes: ['source.python', scope, 'punctuation.definition.string.begin.python']
+      expect(tokens[2]).toEqual value: '%d', scopes: ['source.python', scope, 'constant.other.placeholder.python']
+      expect(tokens[3]).toEqual value: '[', scopes: ['source.python', scope, 'constant.other.character-class.set.regexp', 'punctuation.definition.character-class.regexp']
+      expect(tokens[4]).toEqual value: delim, scopes: ['source.python', scope, 'punctuation.definition.string.end.python']
+      expect(tokens[5]).toEqual value: ' ', scopes: ['source.python']
+      expect(tokens[6]).toEqual value: '#', scopes: ['source.python', 'comment.line.number-sign.python', 'punctuation.definition.comment.python']
+      expect(tokens[7]).toEqual value: 'foo', scopes: ['source.python', 'comment.line.number-sign.python']
 
   it "terminates referencing an item in a list variable after a sequence of a closing and opening bracket", ->
-    tokens = grammar.tokenizeLines('foo[i[0]][j[0]]')
+    {tokens} = grammar.tokenizeLine('foo[i[0]][j[0]]')
 
-    expect(tokens[0][0].value).toBe 'foo'
-    expect(tokens[0][0].scopes).toEqual ['source.python', 'meta.item-access.python']
-    expect(tokens[0][1].value).toBe '['
-    expect(tokens[0][1].scopes).toEqual ['source.python', 'meta.item-access.python', 'punctuation.definition.arguments.begin.python']
-    expect(tokens[0][2].value).toBe 'i'
-    expect(tokens[0][2].scopes).toEqual ['source.python', 'meta.item-access.python', 'meta.item-access.arguments.python', 'meta.item-access.python']
-    expect(tokens[0][3].value).toBe '['
-    expect(tokens[0][3].scopes).toEqual ['source.python', 'meta.item-access.python', 'meta.item-access.arguments.python', 'meta.item-access.python', 'punctuation.definition.arguments.begin.python']
-    expect(tokens[0][4].value).toBe '0'
-    expect(tokens[0][4].scopes).toEqual ['source.python', 'meta.item-access.python', 'meta.item-access.arguments.python', 'meta.item-access.python', 'meta.item-access.arguments.python', 'constant.numeric.integer.decimal.python']
-    expect(tokens[0][5].value).toBe ']'
-    expect(tokens[0][5].scopes).toEqual ['source.python', 'meta.item-access.python', 'meta.item-access.arguments.python', 'meta.item-access.python', 'punctuation.definition.arguments.end.python']
-    expect(tokens[0][6].value).toBe ']'
-    expect(tokens[0][6].scopes).toEqual ['source.python', 'meta.item-access.python', 'punctuation.definition.arguments.end.python']
-    expect(tokens[0][7].value).toBe '['
-    expect(tokens[0][7].scopes).toEqual ['source.python', 'meta.structure.list.python', 'punctuation.definition.list.begin.python']
-    expect(tokens[0][8].value).toBe 'j'
-    expect(tokens[0][8].scopes).toEqual ['source.python', 'meta.structure.list.python', 'meta.structure.list.item.python', 'meta.item-access.python']
-    expect(tokens[0][9].value).toBe '['
-    expect(tokens[0][9].scopes).toEqual ['source.python', 'meta.structure.list.python', 'meta.structure.list.item.python', 'meta.item-access.python', 'punctuation.definition.arguments.begin.python']
-    expect(tokens[0][10].value).toBe '0'
-    expect(tokens[0][10].scopes).toEqual ['source.python', 'meta.structure.list.python', 'meta.structure.list.item.python', 'meta.item-access.python', 'meta.item-access.arguments.python', 'constant.numeric.integer.decimal.python']
-    expect(tokens[0][11].value).toBe ']'
-    expect(tokens[0][11].scopes).toEqual ['source.python', 'meta.structure.list.python', 'meta.structure.list.item.python', 'meta.item-access.python', 'punctuation.definition.arguments.end.python']
-    expect(tokens[0][12].value).toBe ']'
-    expect(tokens[0][12].scopes).toEqual ['source.python', 'meta.structure.list.python', 'punctuation.definition.list.end.python']
+    expect(tokens[0]).toEqual value: 'foo', scopes: ['source.python', 'meta.item-access.python']
+    expect(tokens[1]).toEqual value: '[', scopes: ['source.python', 'meta.item-access.python', 'punctuation.definition.arguments.begin.python']
+    expect(tokens[2]).toEqual value: 'i', scopes: ['source.python', 'meta.item-access.python', 'meta.item-access.arguments.python', 'meta.item-access.python']
+    expect(tokens[3]).toEqual value: '[', scopes: ['source.python', 'meta.item-access.python', 'meta.item-access.arguments.python', 'meta.item-access.python', 'punctuation.definition.arguments.begin.python']
+    expect(tokens[4]).toEqual value: '0', scopes: ['source.python', 'meta.item-access.python', 'meta.item-access.arguments.python', 'meta.item-access.python', 'meta.item-access.arguments.python', 'constant.numeric.integer.decimal.python']
+    expect(tokens[5]).toEqual value: ']', scopes: ['source.python', 'meta.item-access.python', 'meta.item-access.arguments.python', 'meta.item-access.python', 'punctuation.definition.arguments.end.python']
+    expect(tokens[6]).toEqual value: ']', scopes: ['source.python', 'meta.item-access.python', 'punctuation.definition.arguments.end.python']
+    expect(tokens[7]).toEqual value: '[', scopes: ['source.python', 'meta.structure.list.python', 'punctuation.definition.list.begin.python']
+    expect(tokens[8]).toEqual value: 'j', scopes: ['source.python', 'meta.structure.list.python', 'meta.structure.list.item.python', 'meta.item-access.python']
+    expect(tokens[9]).toEqual value: '[', scopes: ['source.python', 'meta.structure.list.python', 'meta.structure.list.item.python', 'meta.item-access.python', 'punctuation.definition.arguments.begin.python']
+    expect(tokens[10]).toEqual value: '0', scopes: ['source.python', 'meta.structure.list.python', 'meta.structure.list.item.python', 'meta.item-access.python', 'meta.item-access.arguments.python', 'constant.numeric.integer.decimal.python']
+    expect(tokens[11]).toEqual value: ']', scopes: ['source.python', 'meta.structure.list.python', 'meta.structure.list.item.python', 'meta.item-access.python', 'punctuation.definition.arguments.end.python']
+    expect(tokens[12]).toEqual value: ']', scopes: ['source.python', 'meta.structure.list.python', 'punctuation.definition.list.end.python']
 
   it "tokenizes properties of self as variables", ->
-    tokens = grammar.tokenizeLines('self.foo')
+    {tokens} = grammar.tokenizeLine('self.foo')
 
-    expect(tokens[0][0].value).toBe 'self'
-    expect(tokens[0][0].scopes).toEqual ['source.python', 'variable.language.python']
-    expect(tokens[0][1].value).toBe '.'
-    expect(tokens[0][1].scopes).toEqual ['source.python']
-    expect(tokens[0][2].value).toBe 'foo'
-    expect(tokens[0][2].scopes).toEqual ['source.python']
+    expect(tokens[0]).toEqual value: 'self', scopes: ['source.python', 'variable.language.python']
+    expect(tokens[1]).toEqual value: '.', scopes: ['source.python']
+    expect(tokens[2]).toEqual value: 'foo', scopes: ['source.python']
 
   it "tokenizes properties of a variable as variables", ->
-    tokens = grammar.tokenizeLines('bar.foo')
+    {tokens} = grammar.tokenizeLine('bar.foo')
 
-    expect(tokens[0][0].value).toBe 'bar'
-    expect(tokens[0][0].scopes).toEqual ['source.python']
-    expect(tokens[0][1].value).toBe '.'
-    expect(tokens[0][1].scopes).toEqual ['source.python']
-    expect(tokens[0][2].value).toBe 'foo'
-    expect(tokens[0][2].scopes).toEqual ['source.python']
+    expect(tokens[0]).toEqual value: 'bar', scopes: ['source.python']
+    expect(tokens[1]).toEqual value: '.', scopes: ['source.python']
+    expect(tokens[2]).toEqual value: 'foo', scopes: ['source.python']
 
   it "tokenizes comments inside function parameters", ->
     {tokens} = grammar.tokenizeLine('def test(arg, # comment')
@@ -257,13 +134,13 @@ describe "Python grammar", ->
     expect(tokens[7]).toEqual value: '#', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'comment.line.number-sign.python', 'punctuation.definition.comment.python']
     expect(tokens[8]).toEqual value: ' comment', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'comment.line.number-sign.python']
 
-    tokens = grammar.tokenizeLines("""
+    tokens = grammar.tokenizeLines """
       def __init__(
         self,
         codec, # comment
         config
       ):
-    """)
+    """
 
     expect(tokens[0][0]).toEqual value: 'def', scopes: ['source.python', 'meta.function.python', 'storage.type.function.python']
     expect(tokens[0][2]).toEqual value: '__init__', scopes: ['source.python', 'meta.function.python', 'entity.name.function.python', 'support.function.magic.python']
@@ -277,4 +154,3 @@ describe "Python grammar", ->
     expect(tokens[3][1]).toEqual value: 'config', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'variable.parameter.function.python']
     expect(tokens[4][0]).toEqual value: ')', scopes: ['source.python', 'meta.function.python', 'punctuation.definition.parameters.end.python']
     expect(tokens[4][1]).toEqual value: ':', scopes: ['source.python', 'meta.function.python', 'punctuation.section.function.begin.python']
-


### PR DESCRIPTION
I took a look at the specs while reviewing some recent PRs and found a lot of unnecessary code, so I decided to improve it.
- `tokenizeLines` is no longer used unless strictly necessary
  - In addition, where it is used, the lines are actually on different lines rather than being separated by `\n`
- Duplicated tests to test for `'` and `"` have been combined
- Token assertions now happen on one line instead of two

All in all, these changes almost halve the size of the specs file.  However, there are still some changes that would be nice to have but I'm not sure how to implement:
- [ ] Even after the quote deduplication, there still is a lot of duplicated tests where the only difference is the use of `(` or `[`.  I don't know how to make that into a for loop because more than one scope changes.
- [ ] Down over at line 122, all three assertions have the same scope, yet I can't combine them into one.  No idea why that is.
