### PR TITLE
Fix inline SQL  in Python Grammar for block strings with starting new lines

### DIFF
--- a/grammars/python.cson
+++ b/grammars/python.cson
@@ -1137,7 +1137,7 @@
         ]
       }
       {
-        'begin': '(""")(?=\\s*(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER))'
+        'begin': '(""")'
         'beginCaptures':
           '1':
             'name': 'punctuation.definition.string.begin.python'
@@ -1151,13 +1151,19 @@
         'name': 'string.quoted.double.block.sql.python'
         'patterns': [
           {
+             'begin': '(?=\\s*(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER))'
+             'end': '(?=\\s*""")'
+             'patterns': [
+                {
+                  'include': 'source.sql'
+                }
+             ]
+          }
+          {
             'include': '#constant_placeholder'
           }
           {
             'include': '#escaped_char'
-          }
-          {
-            'include': 'source.sql'
           }
         ]
       }
@@ -1499,7 +1505,7 @@
         ]
       }
       {
-        'begin': '(\'\'\')(?=\\s*(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER))'
+        'begin': '(\'\'\')'
         'beginCaptures':
           '1':
             'name': 'punctuation.definition.string.begin.python'
@@ -1510,16 +1516,22 @@
             'name': 'punctuation.definition.string.end.python'
           '2':
             'name': 'meta.empty-string.single.python'
-        'name': 'string.quoted.single.block.python'
+        'name': 'string.quoted.single.block.sql.python'
         'patterns': [
+          {
+             'begin': '(?=\\s*(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER))'
+             'end': '(?=\\s*\'\'\')'
+             'patterns': [
+                {
+                  'include': 'source.sql'
+                }
+             ]
+          }
           {
             'include': '#constant_placeholder'
           }
           {
             'include': '#escaped_char'
-          }
-          {
-            'include': 'source.sql'
           }
         ]
       }

--- a/spec/python-spec.coffee
+++ b/spec/python-spec.coffee
@@ -289,7 +289,7 @@ describe "Python grammar", ->
         """
         '''
         quotes: '"""'
-        scope: 'string.quoted.double.block.sql.python'
+        blockScope: 'string.quoted.double.block.sql.python'
       }
       {
         text: """
@@ -299,14 +299,14 @@ describe "Python grammar", ->
         '''
         """
         quotes: "'''"
-        scope: 'string.quoted.single.block.sql.python'
+        blockScope: 'string.quoted.single.block.sql.python'
       }
     ]
 
     for test in testCases
       tokens =  grammar.tokenizeLines(test['text'])
 
-      expect(tokens[0][0]).toEqual value: test['quotes'], scopes: ['source.python', test['scope'], 'punctuation.definition.string.begin.python']
-      expect(tokens[1][0]).toEqual value: 'SELECT bar', scopes: ['source.python', test['scope']]
-      expect(tokens[2][0]).toEqual value: 'FROM foo', scopes: ['source.python', test['scope']]
-      expect(tokens[3][0]).toEqual value: test['quotes'], scopes: ['source.python', test['scope'], 'punctuation.definition.string.end.python']
+      expect(tokens[0][0]).toEqual value: test['quotes'], scopes: ['source.python', test['blockScope'], 'punctuation.definition.string.begin.python']
+      expect(tokens[1][0]).toEqual value: 'SELECT bar', scopes: ['source.python', test['blockScope']]
+      expect(tokens[2][0]).toEqual value: 'FROM foo', scopes: ['source.python', test['blockScope']]
+      expect(tokens[3][0]).toEqual value: test['quotes'], scopes: ['source.python', test['blockScope'], 'punctuation.definition.string.end.python']

--- a/spec/python-spec.coffee
+++ b/spec/python-spec.coffee
@@ -278,3 +278,28 @@ describe "Python grammar", ->
     expect(tokens[4][0]).toEqual value: ')', scopes: ['source.python', 'meta.function.python', 'punctuation.definition.parameters.end.python']
     expect(tokens[4][1]).toEqual value: ':', scopes: ['source.python', 'meta.function.python', 'punctuation.section.function.begin.python']
 
+
+  it "correctly enables SQL inline highlighting on blocks", ->
+    tokens = grammar.tokenizeLines('''
+      """
+      SELECT bar
+      FROM foo
+      """
+    ''')
+
+    expect(tokens[0][0]).toEqual value: '"""', scopes: ['source.python', 'string.quoted.double.block.sql.python', 'punctuation.definition.string.begin.python']
+    expect(tokens[1][0]).toEqual value: 'SELECT bar', scopes: ['source.python', 'string.quoted.double.block.sql.python']
+    expect(tokens[2][0]).toEqual value: 'FROM foo', scopes: ['source.python', 'string.quoted.double.block.sql.python']
+    expect(tokens[3][0]).toEqual value: '"""', scopes: ['source.python', 'string.quoted.double.block.sql.python', 'punctuation.definition.string.end.python']
+
+    tokens = grammar.tokenizeLines("""
+      '''
+      SELECT bar
+      FROM foo
+      '''
+    """)
+
+    expect(tokens[0][0]).toEqual value: '\'\'\'', scopes: ['source.python', 'string.quoted.single.block.sql.python', 'punctuation.definition.string.begin.python']
+    expect(tokens[1][0]).toEqual value: 'SELECT bar', scopes: ['source.python', 'string.quoted.single.block.sql.python']
+    expect(tokens[2][0]).toEqual value: 'FROM foo', scopes: ['source.python', 'string.quoted.single.block.sql.python']
+    expect(tokens[3][0]).toEqual value: '\'\'\'', scopes: ['source.python', 'string.quoted.single.block.sql.python', 'punctuation.definition.string.end.python']

--- a/spec/python-spec.coffee
+++ b/spec/python-spec.coffee
@@ -279,7 +279,7 @@ describe "Python grammar", ->
     expect(tokens[4][1]).toEqual value: ':', scopes: ['source.python', 'meta.function.python', 'punctuation.section.function.begin.python']
 
 
-  it "correctly enables SQL inline highlighting on blocks", ->
+  it "tokenizes SQL inline highlighting on blocks", ->
     tokens = grammar.tokenizeLines('''
       """
       SELECT bar

--- a/spec/python-spec.coffee
+++ b/spec/python-spec.coffee
@@ -280,33 +280,19 @@ describe "Python grammar", ->
 
 
   it "tokenizes SQL inline highlighting on blocks", ->
-    testCases = [
-      {
-        text: '''
-        """
-        SELECT bar
-        FROM foo
-        """
-        '''
-        quotes: '"""'
-        blockScope: 'string.quoted.double.block.sql.python'
-      }
-      {
-        text: """
-        '''
-        SELECT bar
-        FROM foo
-        '''
-        """
-        quotes: "'''"
-        blockScope: 'string.quoted.single.block.sql.python'
-      }
-    ]
+    delimsByScope =
+      "string.quoted.double.block.sql.python": '"""'
+      "string.quoted.single.block.sql.python": "'''"
 
-    for test in testCases
-      tokens =  grammar.tokenizeLines(test['text'])
+    for scope, delim in delimsByScope
+      tokens =  grammar.tokenizeLines(
+        delim +
+        'SELECT bar
+        FROM foo'
+        + delim
+      )
 
-      expect(tokens[0][0]).toEqual value: test['quotes'], scopes: ['source.python', test['blockScope'], 'punctuation.definition.string.begin.python']
-      expect(tokens[1][0]).toEqual value: 'SELECT bar', scopes: ['source.python', test['blockScope']]
-      expect(tokens[2][0]).toEqual value: 'FROM foo', scopes: ['source.python', test['blockScope']]
-      expect(tokens[3][0]).toEqual value: test['quotes'], scopes: ['source.python', test['blockScope'], 'punctuation.definition.string.end.python']
+      expect(tokens[0][0]).toEqual value: delim, scopes: ['source.python', scope, 'punctuation.definition.string.begin.python']
+      expect(tokens[1][0]).toEqual value: 'SELECT bar', scopes: ['source.python', scope]
+      expect(tokens[2][0]).toEqual value: 'FROM foo', scopes: ['source.python', scope]
+      expect(tokens[3][0]).toEqual value: delim, scopes: ['source.python', scope, 'punctuation.definition.string.end.python']

--- a/spec/python-spec.coffee
+++ b/spec/python-spec.coffee
@@ -280,26 +280,33 @@ describe "Python grammar", ->
 
 
   it "tokenizes SQL inline highlighting on blocks", ->
-    tokens = grammar.tokenizeLines('''
-      """
-      SELECT bar
-      FROM foo
-      """
-    ''')
+    testCases = [
+      {
+        text: '''
+        """
+        SELECT bar
+        FROM foo
+        """
+        '''
+        quotes: '"""'
+        scope: 'string.quoted.double.block.sql.python'
+      }
+      {
+        text: """
+        '''
+        SELECT bar
+        FROM foo
+        '''
+        """
+        quotes: "'''"
+        scope: 'string.quoted.single.block.sql.python'
+      }
+    ]
 
-    expect(tokens[0][0]).toEqual value: '"""', scopes: ['source.python', 'string.quoted.double.block.sql.python', 'punctuation.definition.string.begin.python']
-    expect(tokens[1][0]).toEqual value: 'SELECT bar', scopes: ['source.python', 'string.quoted.double.block.sql.python']
-    expect(tokens[2][0]).toEqual value: 'FROM foo', scopes: ['source.python', 'string.quoted.double.block.sql.python']
-    expect(tokens[3][0]).toEqual value: '"""', scopes: ['source.python', 'string.quoted.double.block.sql.python', 'punctuation.definition.string.end.python']
+    for test in testCases
+      tokens =  grammar.tokenizeLines(test['text'])
 
-    tokens = grammar.tokenizeLines("""
-      '''
-      SELECT bar
-      FROM foo
-      '''
-    """)
-
-    expect(tokens[0][0]).toEqual value: '\'\'\'', scopes: ['source.python', 'string.quoted.single.block.sql.python', 'punctuation.definition.string.begin.python']
-    expect(tokens[1][0]).toEqual value: 'SELECT bar', scopes: ['source.python', 'string.quoted.single.block.sql.python']
-    expect(tokens[2][0]).toEqual value: 'FROM foo', scopes: ['source.python', 'string.quoted.single.block.sql.python']
-    expect(tokens[3][0]).toEqual value: '\'\'\'', scopes: ['source.python', 'string.quoted.single.block.sql.python', 'punctuation.definition.string.end.python']
+      expect(tokens[0][0]).toEqual value: test['quotes'], scopes: ['source.python', test['scope'], 'punctuation.definition.string.begin.python']
+      expect(tokens[1][0]).toEqual value: 'SELECT bar', scopes: ['source.python', test['scope']]
+      expect(tokens[2][0]).toEqual value: 'FROM foo', scopes: ['source.python', test['scope']]
+      expect(tokens[3][0]).toEqual value: test['quotes'], scopes: ['source.python', test['scope'], 'punctuation.definition.string.end.python']

--- a/spec/python-spec.coffee
+++ b/spec/python-spec.coffee
@@ -285,7 +285,7 @@ describe "Python grammar", ->
       "string.quoted.single.block.sql.python": "'''"
 
     for scope, delim in delimsByScope
-      tokens =  grammar.tokenizeLines(
+      tokens = grammar.tokenizeLines(
         delim +
         'SELECT bar
         FROM foo'


### PR DESCRIPTION
Fixes inline SQL syntax highlighting for the following two scenarios:

```
query = """
SELECT *
FROM foo
"""
```

and

```
query = '''
SELECT *
FROM bar
'''
```