### PR TITLE
Add support for function annotations

### DIFF
--- a/grammars/python.cson
+++ b/grammars/python.cson
@@ -238,13 +238,17 @@
     'beginCaptures':
       '1':
         'name': 'storage.type.function.python'
-    'end': '(\\))\\s*(?:(\\:)|(.*$\\n?))'
+    'end': '(\\))\\s*(?:(->)\\s*([A-Za-z_][A-Za-z0-9_]*)\\s*)?(?:(\\:)|(.*$\\n?))'
     'endCaptures':
       '1':
         'name': 'punctuation.definition.parameters.end.python'
       '2':
-        'name': 'punctuation.section.function.begin.python'
+        'name': 'punctuation.definition.annotation.return.python'
       '3':
+        'name': 'variable.annotation.function.python'
+      '4':
+        'name': 'punctuation.section.function.begin.python'
+      '5':
         'name': 'invalid.illegal.missing-section-begin.python'
     'name': 'meta.function.python'
     'patterns': [
@@ -277,8 +281,12 @@
               '1':
                 'name': 'variable.parameter.function.python'
               '2':
+                'name': 'punctuation.definition.annotation.parameter.python'
+              '3':
+                'name': 'variable.annotation.function.python'
+              '4':
                 'name': 'punctuation.separator.parameters.python'
-            'match': '\\b([a-zA-Z_][a-zA-Z_0-9]*)\\s*(?:(,)|\\:\\s*\\w*(,*))'
+            'match': '\\b([a-zA-Z_][a-zA-Z_0-9]*)\\s*(?:(:)\\s*([a-zA-Z_][a-zA-Z_0-9]*))?(?:(,)|(?=[\\n\\)]))'
           }
         ]
       }

--- a/grammars/python.cson
+++ b/grammars/python.cson
@@ -245,7 +245,7 @@
       '2':
         'name': 'punctuation.definition.annotation.return.python'
       '3':
-        'name': 'variable.annotation.function.python'
+        'name': 'variable.other.annotation'
       '4':
         'name': 'punctuation.section.function.begin.python'
       '5':

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-python",
-  "version": "0.39.0",
+  "version": "0.40.0",
   "engines": {
     "atom": "*",
     "node": "*"

--- a/spec/python-spec.coffee
+++ b/spec/python-spec.coffee
@@ -300,7 +300,7 @@ describe "Python grammar", ->
     tokens = grammar.tokenizeLines('def f(a: int) -> int:')
 
     expect(tokens[0][0]).toEqual value: 'def', scopes: ['source.python', 'meta.function.python', 'storage.type.function.python']
-    expect(tokens[0][2]).toEqual value: 'f', scopes: ['source.python', 'meta.function.python', 'entity.name.function.python', 'support.function.magic.python']
+    expect(tokens[0][2]).toEqual value: 'f', scopes: ['source.python', 'meta.function.python', 'entity.name.function.python']
     expect(tokens[0][3]).toEqual value: '(', scopes: ['source.python', 'meta.function.python', 'punctuation.definition.parameters.begin.python']
     expect(tokens[1][1]).toEqual value: 'a', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'variable.parameter.function.python']
     expect(tokens[1][2]).toEqual value: ':', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'punctuation.definition.annotation.parameter.python']

--- a/spec/python-spec.coffee
+++ b/spec/python-spec.coffee
@@ -296,3 +296,16 @@ describe "Python grammar", ->
       expect(tokens[1][0]).toEqual value: 'SELECT bar', scopes: ['source.python', scope]
       expect(tokens[2][0]).toEqual value: 'FROM foo', scopes: ['source.python', scope]
       expect(tokens[3][0]).toEqual value: delim, scopes: ['source.python', scope, 'punctuation.definition.string.end.python']
+  it "tokenizes a function definition with annotations", ->
+    tokens = grammar.tokenizeLines('def f(a: int) -> int:')
+
+    expect(tokens[0][0]).toEqual value: 'def', scopes: ['source.python', 'meta.function.python', 'storage.type.function.python']
+    expect(tokens[0][2]).toEqual value: 'f', scopes: ['source.python', 'meta.function.python', 'entity.name.function.python', 'support.function.magic.python']
+    expect(tokens[0][3]).toEqual value: '(', scopes: ['source.python', 'meta.function.python', 'punctuation.definition.parameters.begin.python']
+    expect(tokens[1][1]).toEqual value: 'a', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'variable.parameter.function.python']
+    expect(tokens[1][2]).toEqual value: ':', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'punctuation.definition.annotation.parameter.python']
+    expect(tokens[2][1]).toEqual value: 'int', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'variable.annotation.function.python']
+    expect(tokens[4][0]).toEqual value: ')', scopes: ['source.python', 'meta.function.python', 'punctuation.definition.parameters.end.python']
+    expect(tokens[4][0]).toEqual value: '->', scopes: ['source.python', 'meta.function.python', 'punctuation.definition.annotation.return.python']
+    expect(tokens[4][0]).toEqual value: 'int', scopes: ['source.python', 'meta.function.python', 'variable.annotation.function.python']
+    expect(tokens[4][1]).toEqual value: ':', scopes: ['source.python', 'meta.function.python', 'punctuation.section.function.begin.python']


### PR DESCRIPTION
This thing is not quite working
I get a new `support.function.magic.python` apparently from nowhere

If someone can fix this and complete the PR for me that'd be nice, or also explain how the scopes names are pulled together

I tried to have a look at [this](https://atom.io/docs/latest/contributing), but it doesn't to deal with technical stuff
