### PR TITLE
Stop regex matching at the end of a string

### DIFF
--- a/grammars/regular expressions (python).cson
+++ b/grammars/regular expressions (python).cson
@@ -1,10 +1,11 @@
+'name': 'Regular Expressions (Python)'
+'scopeName': 'source.regexp.python'
 'comment': 'Matches Python\'s regular expression syntax.'
+'foldingStartMarker': '(/\\*|\\{|\\()'
+'foldingStopMarker': '(\\*/|\\}|\\))'
 'fileTypes': [
   're'
 ]
-'foldingStartMarker': '(/\\*|\\{|\\()'
-'foldingStopMarker': '(\\*/|\\}|\\))'
-'name': 'Regular Expressions (Python)'
 'patterns': [
   {
     'match': '\\\\[bBAZzG]|\\^|\\$'
@@ -55,7 +56,7 @@
         'name': 'meta.assertion.look-behind.regexp'
       '6':
         'name': 'meta.assertion.negative-look-behind.regexp'
-    'end': '(\\))'
+    'end': '(\\))|(?="""|\'\'\')'
     'endCaptures':
       '1':
         'name': 'punctuation.definition.group.regexp'
@@ -76,7 +77,7 @@
       '3':
         'name': 'entity.name.section.back-reference.regexp'
     'comment': 'we can make this more sophisticated to match the | character that separates yes-pattern from no-pattern, but it\'s not really necessary.'
-    'end': '(\\))'
+    'end': '(\\))|(?="""|\'\'\')'
     'name': 'meta.group.assertion.conditional.regexp'
     'patterns': [
       {
@@ -97,7 +98,7 @@
         'name': 'punctuation.definition.group.capture.regexp'
       '6':
         'name': 'punctuation.definition.group.no-capture.regexp'
-    'end': '(\\))'
+    'end': '(\\))|(?="""|\'\'\')'
     'endCaptures':
       '1':
         'name': 'punctuation.definition.group.regexp'
@@ -130,7 +131,7 @@
             'name': 'punctuation.definition.character-class.regexp'
           '2':
             'name': 'keyword.operator.negation.regexp'
-        'end': '(\\])'
+        'end': '(\\])|(?="""|\'\'\')'
         'endCaptures':
           '1':
             'name': 'punctuation.definition.character-class.regexp'
@@ -151,4 +152,3 @@
         ]
       }
     ]
-'scopeName': 'source.regexp.python'

--- a/spec/python-spec.coffee
+++ b/spec/python-spec.coffee
@@ -36,165 +36,161 @@ describe "Python grammar", ->
 
     expect(tokens[1][2]).not.toBeDefined()
 
-  it "terminates a single-quoted raw string containing opening parenthesis at closing quote", ->
-    tokens = grammar.tokenizeLines("r'%d(' #foo")
+  it "terminates a single-line raw string containing unmatched parentheses", ->
+    delimsByScope =
+      'string.quoted.double.single-line.raw-regex.python': '"'
+      'string.quoted.single.single-line.raw-regex.python': "'"
 
-    expect(tokens[0][0].value).toBe 'r'
-    expect(tokens[0][0].scopes).toEqual ['source.python', 'string.quoted.single.single-line.raw-regex.python', 'storage.type.string.python']
-    expect(tokens[0][1].value).toBe "'"
-    expect(tokens[0][1].scopes).toEqual ['source.python', 'string.quoted.single.single-line.raw-regex.python', 'punctuation.definition.string.begin.python']
-    expect(tokens[0][2].value).toBe '%d'
-    expect(tokens[0][2].scopes).toEqual ['source.python', 'string.quoted.single.single-line.raw-regex.python', 'constant.other.placeholder.python']
-    expect(tokens[0][3].value).toBe '('
-    expect(tokens[0][3].scopes).toEqual ['source.python', 'string.quoted.single.single-line.raw-regex.python', 'meta.group.regexp', 'punctuation.definition.group.regexp']
-    expect(tokens[0][4].value).toBe "'"
-    expect(tokens[0][4].scopes).toEqual ['source.python', 'string.quoted.single.single-line.raw-regex.python', 'punctuation.definition.string.end.python']
-    expect(tokens[0][5].value).toBe ' '
-    expect(tokens[0][5].scopes).toEqual ['source.python']
-    expect(tokens[0][6].value).toBe '#'
-    expect(tokens[0][6].scopes).toEqual ['source.python', 'comment.line.number-sign.python', 'punctuation.definition.comment.python']
-    expect(tokens[0][7].value).toBe 'foo'
-    expect(tokens[0][7].scopes).toEqual ['source.python', 'comment.line.number-sign.python']
+    for scope, delim of delimsByScope
+      tokens = grammar.tokenizeLines("r" + delim + "%d(" + delim + " #foo")
 
-  it "terminates a single-quoted raw string containing opening bracket at closing quote", ->
-    tokens = grammar.tokenizeLines("r'%d[' #foo")
+      expect(tokens[0][0].value).toBe 'r'
+      expect(tokens[0][0].scopes).toEqual ['source.python', scope, 'storage.type.string.python']
+      expect(tokens[0][1].value).toBe delim
+      expect(tokens[0][1].scopes).toEqual ['source.python', scope, 'punctuation.definition.string.begin.python']
+      expect(tokens[0][2].value).toBe '%d'
+      expect(tokens[0][2].scopes).toEqual ['source.python', scope, 'constant.other.placeholder.python']
+      expect(tokens[0][3].value).toBe '('
+      expect(tokens[0][3].scopes).toEqual ['source.python', scope, 'meta.group.regexp', 'punctuation.definition.group.regexp']
+      expect(tokens[0][4].value).toBe delim
+      expect(tokens[0][4].scopes).toEqual ['source.python', scope, 'punctuation.definition.string.end.python']
+      expect(tokens[0][5].value).toBe ' '
+      expect(tokens[0][5].scopes).toEqual ['source.python']
+      expect(tokens[0][6].value).toBe '#'
+      expect(tokens[0][6].scopes).toEqual ['source.python', 'comment.line.number-sign.python', 'punctuation.definition.comment.python']
+      expect(tokens[0][7].value).toBe 'foo'
+      expect(tokens[0][7].scopes).toEqual ['source.python', 'comment.line.number-sign.python']
 
-    expect(tokens[0][0].value).toBe 'r'
-    expect(tokens[0][0].scopes).toEqual ['source.python', 'string.quoted.single.single-line.raw-regex.python', 'storage.type.string.python']
-    expect(tokens[0][1].value).toBe "'"
-    expect(tokens[0][1].scopes).toEqual ['source.python', 'string.quoted.single.single-line.raw-regex.python', 'punctuation.definition.string.begin.python']
-    expect(tokens[0][2].value).toBe '%d'
-    expect(tokens[0][2].scopes).toEqual ['source.python', 'string.quoted.single.single-line.raw-regex.python', 'constant.other.placeholder.python']
-    expect(tokens[0][3].value).toBe '['
-    expect(tokens[0][3].scopes).toEqual ['source.python', 'string.quoted.single.single-line.raw-regex.python', 'constant.other.character-class.set.regexp', 'punctuation.definition.character-class.regexp']
-    expect(tokens[0][4].value).toBe "'"
-    expect(tokens[0][4].scopes).toEqual ['source.python', 'string.quoted.single.single-line.raw-regex.python', 'punctuation.definition.string.end.python']
-    expect(tokens[0][5].value).toBe ' '
-    expect(tokens[0][5].scopes).toEqual ['source.python']
-    expect(tokens[0][6].value).toBe '#'
-    expect(tokens[0][6].scopes).toEqual ['source.python', 'comment.line.number-sign.python', 'punctuation.definition.comment.python']
-    expect(tokens[0][7].value).toBe 'foo'
-    expect(tokens[0][7].scopes).toEqual ['source.python', 'comment.line.number-sign.python']
+  it "terminates a block raw string containing unmatched parentheses", ->
+    delimsByScope =
+      'string.quoted.double.block.raw-regex.python': '"""'
+      'string.quoted.single.block.raw-regex.python': "'''"
 
-  it "terminates a double-quoted raw string containing opening parenthesis at closing quote", ->
-    tokens = grammar.tokenizeLines('r"%d(" #foo')
+    for scope, delim of delimsByScope
+      tokens = grammar.tokenizeLines("""
+        r#{delim}%d(
+        #{delim} #foo
+      """)
 
-    expect(tokens[0][0].value).toBe 'r'
-    expect(tokens[0][0].scopes).toEqual ['source.python', 'string.quoted.double.single-line.raw-regex.python', 'storage.type.string.python']
-    expect(tokens[0][1].value).toBe '"'
-    expect(tokens[0][1].scopes).toEqual ['source.python', 'string.quoted.double.single-line.raw-regex.python', 'punctuation.definition.string.begin.python']
-    expect(tokens[0][2].value).toBe '%d'
-    expect(tokens[0][2].scopes).toEqual ['source.python', 'string.quoted.double.single-line.raw-regex.python', 'constant.other.placeholder.python']
-    expect(tokens[0][3].value).toBe '('
-    expect(tokens[0][3].scopes).toEqual ['source.python', 'string.quoted.double.single-line.raw-regex.python', 'meta.group.regexp', 'punctuation.definition.group.regexp']
-    expect(tokens[0][4].value).toBe '"'
-    expect(tokens[0][4].scopes).toEqual ['source.python', 'string.quoted.double.single-line.raw-regex.python', 'punctuation.definition.string.end.python']
-    expect(tokens[0][5].value).toBe ' '
-    expect(tokens[0][5].scopes).toEqual ['source.python']
-    expect(tokens[0][6].value).toBe '#'
-    expect(tokens[0][6].scopes).toEqual ['source.python', 'comment.line.number-sign.python', 'punctuation.definition.comment.python']
-    expect(tokens[0][7].value).toBe 'foo'
-    expect(tokens[0][7].scopes).toEqual ['source.python', 'comment.line.number-sign.python']
+      expect(tokens[0][0].value).toBe 'r'
+      expect(tokens[0][0].scopes).toEqual ['source.python', scope, 'storage.type.string.python']
+      expect(tokens[0][1].value).toBe delim
+      expect(tokens[0][1].scopes).toEqual ['source.python', scope, 'punctuation.definition.string.begin.python']
+      expect(tokens[0][2].value).toBe '%d'
+      expect(tokens[0][2].scopes).toEqual ['source.python', scope, 'constant.other.placeholder.python']
+      expect(tokens[0][3].value).toBe '('
+      expect(tokens[0][3].scopes).toEqual ['source.python', scope, 'meta.group.regexp', 'punctuation.definition.group.regexp']
+      expect(tokens[1][0].value).toBe delim
+      expect(tokens[1][0].scopes).toEqual ['source.python', scope, 'punctuation.definition.string.end.python']
+      expect(tokens[1][1].value).toBe ' '
+      expect(tokens[1][1].scopes).toEqual ['source.python']
+      expect(tokens[1][2].value).toBe '#'
+      expect(tokens[1][2].scopes).toEqual ['source.python', 'comment.line.number-sign.python', 'punctuation.definition.comment.python']
+      expect(tokens[1][3].value).toBe 'foo'
+      expect(tokens[1][3].scopes).toEqual ['source.python', 'comment.line.number-sign.python']
 
-  it "terminates a double-quoted raw string containing opening bracket at closing quote", ->
-    tokens = grammar.tokenizeLines('r"%d[" #foo')
+  it "terminates a single-line raw strings containing unmatched brackets", ->
+    delimsByScope =
+      'string.quoted.double.single-line.raw-regex.python': '"'
+      'string.quoted.single.single-line.raw-regex.python': "'"
 
-    expect(tokens[0][0].value).toBe 'r'
-    expect(tokens[0][0].scopes).toEqual ['source.python', 'string.quoted.double.single-line.raw-regex.python', 'storage.type.string.python']
-    expect(tokens[0][1].value).toBe '"'
-    expect(tokens[0][1].scopes).toEqual ['source.python', 'string.quoted.double.single-line.raw-regex.python', 'punctuation.definition.string.begin.python']
-    expect(tokens[0][2].value).toBe '%d'
-    expect(tokens[0][2].scopes).toEqual ['source.python', 'string.quoted.double.single-line.raw-regex.python', 'constant.other.placeholder.python']
-    expect(tokens[0][3].value).toBe '['
-    expect(tokens[0][3].scopes).toEqual ['source.python', 'string.quoted.double.single-line.raw-regex.python', 'constant.other.character-class.set.regexp', 'punctuation.definition.character-class.regexp']
-    expect(tokens[0][4].value).toBe '"'
-    expect(tokens[0][4].scopes).toEqual ['source.python', 'string.quoted.double.single-line.raw-regex.python', 'punctuation.definition.string.end.python']
-    expect(tokens[0][5].value).toBe ' '
-    expect(tokens[0][5].scopes).toEqual ['source.python']
-    expect(tokens[0][6].value).toBe '#'
-    expect(tokens[0][6].scopes).toEqual ['source.python', 'comment.line.number-sign.python', 'punctuation.definition.comment.python']
-    expect(tokens[0][7].value).toBe 'foo'
-    expect(tokens[0][7].scopes).toEqual ['source.python', 'comment.line.number-sign.python']
+    for scope, delim of delimsByScope
+      tokens = grammar.tokenizeLines("r" + delim + "%d[" + delim + " #foo")
 
-  it "terminates a unicode single-quoted raw string containing opening parenthesis at closing quote", ->
-    tokens = grammar.tokenizeLines("ur'%d(' #foo")
+      expect(tokens[0][0].value).toBe 'r'
+      expect(tokens[0][0].scopes).toEqual ['source.python', scope, 'storage.type.string.python']
+      expect(tokens[0][1].value).toBe delim
+      expect(tokens[0][1].scopes).toEqual ['source.python', scope, 'punctuation.definition.string.begin.python']
+      expect(tokens[0][2].value).toBe '%d'
+      expect(tokens[0][2].scopes).toEqual ['source.python', scope, 'constant.other.placeholder.python']
+      expect(tokens[0][3].value).toBe '['
+      expect(tokens[0][3].scopes).toEqual ['source.python', scope, 'constant.other.character-class.set.regexp', 'punctuation.definition.character-class.regexp']
+      expect(tokens[0][4].value).toBe delim
+      expect(tokens[0][4].scopes).toEqual ['source.python', scope, 'punctuation.definition.string.end.python']
+      expect(tokens[0][5].value).toBe ' '
+      expect(tokens[0][5].scopes).toEqual ['source.python']
+      expect(tokens[0][6].value).toBe '#'
+      expect(tokens[0][6].scopes).toEqual ['source.python', 'comment.line.number-sign.python', 'punctuation.definition.comment.python']
+      expect(tokens[0][7].value).toBe 'foo'
+      expect(tokens[0][7].scopes).toEqual ['source.python', 'comment.line.number-sign.python']
 
-    expect(tokens[0][0].value).toBe 'ur'
-    expect(tokens[0][0].scopes).toEqual ['source.python', 'string.quoted.single.single-line.unicode-raw-regex.python', 'storage.type.string.python']
-    expect(tokens[0][1].value).toBe "'"
-    expect(tokens[0][1].scopes).toEqual ['source.python', 'string.quoted.single.single-line.unicode-raw-regex.python', 'punctuation.definition.string.begin.python']
-    expect(tokens[0][2].value).toBe '%d'
-    expect(tokens[0][2].scopes).toEqual ['source.python', 'string.quoted.single.single-line.unicode-raw-regex.python', 'constant.other.placeholder.python']
-    expect(tokens[0][3].value).toBe '('
-    expect(tokens[0][3].scopes).toEqual ['source.python', 'string.quoted.single.single-line.unicode-raw-regex.python', 'meta.group.regexp', 'punctuation.definition.group.regexp']
-    expect(tokens[0][4].value).toBe "'"
-    expect(tokens[0][4].scopes).toEqual ['source.python', 'string.quoted.single.single-line.unicode-raw-regex.python', 'punctuation.definition.string.end.python']
-    expect(tokens[0][5].value).toBe ' '
-    expect(tokens[0][5].scopes).toEqual ['source.python']
-    expect(tokens[0][6].value).toBe '#'
-    expect(tokens[0][6].scopes).toEqual ['source.python', 'comment.line.number-sign.python', 'punctuation.definition.comment.python']
-    expect(tokens[0][7].value).toBe 'foo'
-    expect(tokens[0][7].scopes).toEqual ['source.python', 'comment.line.number-sign.python']
+  it "terminates a block raw string containing unmatched brackets", ->
+    delimsByScope =
+      'string.quoted.double.block.raw-regex.python': '"""'
+      'string.quoted.single.block.raw-regex.python': "'''"
 
-  it "terminates a unicode single-quoted raw string containing opening bracket at closing quote", ->
-    tokens = grammar.tokenizeLines("ur'%d[' #foo")
+    for scope, delim of delimsByScope
+      tokens = grammar.tokenizeLines("""
+        r#{delim}%d[
+        #{delim} #foo
+      """)
 
-    expect(tokens[0][0].value).toBe 'ur'
-    expect(tokens[0][0].scopes).toEqual ['source.python', 'string.quoted.single.single-line.unicode-raw-regex.python', 'storage.type.string.python']
-    expect(tokens[0][1].value).toBe "'"
-    expect(tokens[0][1].scopes).toEqual ['source.python', 'string.quoted.single.single-line.unicode-raw-regex.python', 'punctuation.definition.string.begin.python']
-    expect(tokens[0][2].value).toBe '%d'
-    expect(tokens[0][2].scopes).toEqual ['source.python', 'string.quoted.single.single-line.unicode-raw-regex.python', 'constant.other.placeholder.python']
-    expect(tokens[0][3].value).toBe '['
-    expect(tokens[0][3].scopes).toEqual ['source.python', 'string.quoted.single.single-line.unicode-raw-regex.python', 'constant.other.character-class.set.regexp', 'punctuation.definition.character-class.regexp']
-    expect(tokens[0][4].value).toBe "'"
-    expect(tokens[0][4].scopes).toEqual ['source.python', 'string.quoted.single.single-line.unicode-raw-regex.python', 'punctuation.definition.string.end.python']
-    expect(tokens[0][5].value).toBe ' '
-    expect(tokens[0][5].scopes).toEqual ['source.python']
-    expect(tokens[0][6].value).toBe '#'
-    expect(tokens[0][6].scopes).toEqual ['source.python', 'comment.line.number-sign.python', 'punctuation.definition.comment.python']
-    expect(tokens[0][7].value).toBe 'foo'
-    expect(tokens[0][7].scopes).toEqual ['source.python', 'comment.line.number-sign.python']
+      expect(tokens[0][0].value).toBe 'r'
+      expect(tokens[0][0].scopes).toEqual ['source.python', scope, 'storage.type.string.python']
+      expect(tokens[0][1].value).toBe delim
+      expect(tokens[0][1].scopes).toEqual ['source.python', scope, 'punctuation.definition.string.begin.python']
+      expect(tokens[0][2].value).toBe '%d'
+      expect(tokens[0][2].scopes).toEqual ['source.python', scope, 'constant.other.placeholder.python']
+      expect(tokens[0][3].value).toBe '['
+      expect(tokens[0][3].scopes).toEqual ['source.python', scope, 'constant.other.character-class.set.regexp', 'punctuation.definition.character-class.regexp']
+      expect(tokens[1][0].value).toBe delim
+      expect(tokens[1][0].scopes).toEqual ['source.python', scope, 'punctuation.definition.string.end.python']
+      expect(tokens[1][1].value).toBe ' '
+      expect(tokens[1][1].scopes).toEqual ['source.python']
+      expect(tokens[1][2].value).toBe '#'
+      expect(tokens[1][2].scopes).toEqual ['source.python', 'comment.line.number-sign.python', 'punctuation.definition.comment.python']
+      expect(tokens[1][3].value).toBe 'foo'
+      expect(tokens[1][3].scopes).toEqual ['source.python', 'comment.line.number-sign.python']
 
-  it "terminates a unicode double-quoted raw string containing opening parenthesis at closing quote", ->
-    tokens = grammar.tokenizeLines('ur"%d(" #foo')
+  it "terminates a unicode single-line raw string containing unmatched parentheses", ->
+    delimsByScope =
+      'string.quoted.double.single-line.unicode-raw-regex.python': '"'
+      'string.quoted.single.single-line.unicode-raw-regex.python': "'"
 
-    expect(tokens[0][0].value).toBe 'ur'
-    expect(tokens[0][0].scopes).toEqual ['source.python', 'string.quoted.double.single-line.unicode-raw-regex.python', 'storage.type.string.python']
-    expect(tokens[0][1].value).toBe '"'
-    expect(tokens[0][1].scopes).toEqual ['source.python', 'string.quoted.double.single-line.unicode-raw-regex.python', 'punctuation.definition.string.begin.python']
-    expect(tokens[0][2].value).toBe '%d'
-    expect(tokens[0][2].scopes).toEqual ['source.python', 'string.quoted.double.single-line.unicode-raw-regex.python', 'constant.other.placeholder.python']
-    expect(tokens[0][3].value).toBe '('
-    expect(tokens[0][3].scopes).toEqual ['source.python', 'string.quoted.double.single-line.unicode-raw-regex.python', 'meta.group.regexp', 'punctuation.definition.group.regexp']
-    expect(tokens[0][4].value).toBe '"'
-    expect(tokens[0][4].scopes).toEqual ['source.python', 'string.quoted.double.single-line.unicode-raw-regex.python', 'punctuation.definition.string.end.python']
-    expect(tokens[0][5].value).toBe ' '
-    expect(tokens[0][5].scopes).toEqual ['source.python']
-    expect(tokens[0][6].value).toBe '#'
-    expect(tokens[0][6].scopes).toEqual ['source.python', 'comment.line.number-sign.python', 'punctuation.definition.comment.python']
-    expect(tokens[0][7].value).toBe 'foo'
-    expect(tokens[0][7].scopes).toEqual ['source.python', 'comment.line.number-sign.python']
+    for scope, delim of delimsByScope
+      tokens = grammar.tokenizeLines("ur" + delim + "%d(" + delim + " #foo")
 
-  it "terminates a unicode double-quoted raw string containing opening bracket at closing quote", ->
-    tokens = grammar.tokenizeLines('ur"%d[" #foo')
+      expect(tokens[0][0].value).toBe 'ur'
+      expect(tokens[0][0].scopes).toEqual ['source.python', scope, 'storage.type.string.python']
+      expect(tokens[0][1].value).toBe delim
+      expect(tokens[0][1].scopes).toEqual ['source.python', scope, 'punctuation.definition.string.begin.python']
+      expect(tokens[0][2].value).toBe '%d'
+      expect(tokens[0][2].scopes).toEqual ['source.python', scope, 'constant.other.placeholder.python']
+      expect(tokens[0][3].value).toBe '('
+      expect(tokens[0][3].scopes).toEqual ['source.python', scope, 'meta.group.regexp', 'punctuation.definition.group.regexp']
+      expect(tokens[0][4].value).toBe delim
+      expect(tokens[0][4].scopes).toEqual ['source.python', scope, 'punctuation.definition.string.end.python']
+      expect(tokens[0][5].value).toBe ' '
+      expect(tokens[0][5].scopes).toEqual ['source.python']
+      expect(tokens[0][6].value).toBe '#'
+      expect(tokens[0][6].scopes).toEqual ['source.python', 'comment.line.number-sign.python', 'punctuation.definition.comment.python']
+      expect(tokens[0][7].value).toBe 'foo'
+      expect(tokens[0][7].scopes).toEqual ['source.python', 'comment.line.number-sign.python']
 
-    expect(tokens[0][0].value).toBe 'ur'
-    expect(tokens[0][0].scopes).toEqual ['source.python', 'string.quoted.double.single-line.unicode-raw-regex.python', 'storage.type.string.python']
-    expect(tokens[0][1].value).toBe '"'
-    expect(tokens[0][1].scopes).toEqual ['source.python', 'string.quoted.double.single-line.unicode-raw-regex.python', 'punctuation.definition.string.begin.python']
-    expect(tokens[0][2].value).toBe '%d'
-    expect(tokens[0][2].scopes).toEqual ['source.python', 'string.quoted.double.single-line.unicode-raw-regex.python', 'constant.other.placeholder.python']
-    expect(tokens[0][3].value).toBe '['
-    expect(tokens[0][3].scopes).toEqual ['source.python', 'string.quoted.double.single-line.unicode-raw-regex.python', 'constant.other.character-class.set.regexp', 'punctuation.definition.character-class.regexp']
-    expect(tokens[0][4].value).toBe '"'
-    expect(tokens[0][4].scopes).toEqual ['source.python', 'string.quoted.double.single-line.unicode-raw-regex.python', 'punctuation.definition.string.end.python']
-    expect(tokens[0][5].value).toBe ' '
-    expect(tokens[0][5].scopes).toEqual ['source.python']
-    expect(tokens[0][6].value).toBe '#'
-    expect(tokens[0][6].scopes).toEqual ['source.python', 'comment.line.number-sign.python', 'punctuation.definition.comment.python']
-    expect(tokens[0][7].value).toBe 'foo'
-    expect(tokens[0][7].scopes).toEqual ['source.python', 'comment.line.number-sign.python']
+  it "terminates a unicode single-line raw string containing unmatched brackets", ->
+    delimsByScope =
+      'string.quoted.double.single-line.unicode-raw-regex.python': '"'
+      'string.quoted.single.single-line.unicode-raw-regex.python': "'"
+
+    for scope, delim of delimsByScope
+      tokens = grammar.tokenizeLines("ur" + delim + "%d[" + delim + " #foo")
+
+      expect(tokens[0][0].value).toBe 'ur'
+      expect(tokens[0][0].scopes).toEqual ['source.python', scope, 'storage.type.string.python']
+      expect(tokens[0][1].value).toBe delim
+      expect(tokens[0][1].scopes).toEqual ['source.python', scope, 'punctuation.definition.string.begin.python']
+      expect(tokens[0][2].value).toBe '%d'
+      expect(tokens[0][2].scopes).toEqual ['source.python', scope, 'constant.other.placeholder.python']
+      expect(tokens[0][3].value).toBe '['
+      expect(tokens[0][3].scopes).toEqual ['source.python', scope, 'constant.other.character-class.set.regexp', 'punctuation.definition.character-class.regexp']
+      expect(tokens[0][4].value).toBe delim
+      expect(tokens[0][4].scopes).toEqual ['source.python', scope, 'punctuation.definition.string.end.python']
+      expect(tokens[0][5].value).toBe ' '
+      expect(tokens[0][5].scopes).toEqual ['source.python']
+      expect(tokens[0][6].value).toBe '#'
+      expect(tokens[0][6].scopes).toEqual ['source.python', 'comment.line.number-sign.python', 'punctuation.definition.comment.python']
+      expect(tokens[0][7].value).toBe 'foo'
+      expect(tokens[0][7].scopes).toEqual ['source.python', 'comment.line.number-sign.python']
 
   it "terminates referencing an item in a list variable after a sequence of a closing and opening bracket", ->
     tokens = grammar.tokenizeLines('foo[i[0]][j[0]]')
@@ -284,13 +280,13 @@ describe "Python grammar", ->
       "string.quoted.double.block.sql.python": '"""'
       "string.quoted.single.block.sql.python": "'''"
 
-    for scope, delim in delimsByScope
-      tokens = grammar.tokenizeLines(
-        delim +
-        'SELECT bar
-        FROM foo'
-        + delim
-      )
+    for scope, delim of delimsByScope
+      tokens = grammar.tokenizeLines("""
+        #{delim}
+        SELECT bar
+        FROM foo
+        #{delim}
+      """)
 
       expect(tokens[0][0]).toEqual value: delim, scopes: ['source.python', scope, 'punctuation.definition.string.begin.python']
       expect(tokens[1][0]).toEqual value: 'SELECT bar', scopes: ['source.python', scope]


### PR DESCRIPTION
Regex matching for parentheses or brackets will now stop once it hits the end of the string, even if a matching parenthesis/bracket hasn't been found.

Other than that, this PR also contains the following changes (sorry for not splitting them up into different PRs):
* Reorganized the headers in the regex grammar
* Combined similar tests (this overlaps with #90)
* Fixed a defective test that would pass no matter what

Fixes #39
Fixes #55

/cc @alexjurkiewicz, @auscompgeek, @aroben