### PR TITLE
Add support for CTEs in embedded SQL

### DIFF
--- a/grammars/python.cson
+++ b/grammars/python.cson
@@ -1151,7 +1151,7 @@
         'name': 'string.quoted.double.block.sql.python'
         'patterns': [
           {
-             'begin': '(?=\\s*(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER))'
+             'begin': '(?=\\s*(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER|WITH))'
              'end': '(?=\\s*""")'
              'patterns': [
                 {
@@ -1168,7 +1168,7 @@
         ]
       }
       {
-        'begin': '(")(?=\\s*(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER))'
+        'begin': '(")(?=\\s*(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER|WITH))'
         'beginCaptures':
           '1':
             'name': 'punctuation.definition.string.begin.python'
@@ -1519,7 +1519,7 @@
         'name': 'string.quoted.single.block.sql.python'
         'patterns': [
           {
-             'begin': '(?=\\s*(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER))'
+             'begin': '(?=\\s*(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER|WITH))'
              'end': '(?=\\s*\'\'\')'
              'patterns': [
                 {

--- a/grammars/python.cson
+++ b/grammars/python.cson
@@ -1536,7 +1536,7 @@
         ]
       }
       {
-        'begin': '(\')(?=\\s*(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER))'
+        'begin': '(\')(?=\\s*(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER|WITH))'
         'beginCaptures':
           '1':
             'name': 'punctuation.definition.string.begin.python'

--- a/spec/python-spec.coffee
+++ b/spec/python-spec.coffee
@@ -297,7 +297,6 @@ describe "Python grammar", ->
       expect(tokens[2][0]).toEqual value: 'FROM foo', scopes: ['source.python', scope]
       expect(tokens[3][0]).toEqual value: delim, scopes: ['source.python', scope, 'punctuation.definition.string.end.python']
 
-
   it "tokenizes SQL inline highlighting on blocks with a CTE", ->
     delimsByScope =
       "string.quoted.double.block.sql.python": '"""'
@@ -328,10 +327,10 @@ describe "Python grammar", ->
       expect(tokens[8][0]).toEqual value: 'FROM example_cte', scopes: ['source.python', scope]
       expect(tokens[9][0]).toEqual value: delim, scopes: ['source.python', scope, 'punctuation.definition.string.end.python']
 
-it "tokenizes SQL inline highlighting on single line with a CTE", ->
+  it "tokenizes SQL inline highlighting on single line with a CTE", ->
 
-  tokens = grammar.tokenizeLines('WITH example_cte AS (SELECT bar FROM foo) SELECT COUNT(*) FROM example_cte')
+    tokens = grammar.tokenizeLines('WITH example_cte AS (SELECT bar FROM foo) SELECT COUNT(*) FROM example_cte')
 
-  expect(tokens[0][0]).toEqual value: '\'', scopes: ['source.python', scope, 'punctuation.definition.string.begin.python']
-  expect(tokens[1][0]).toEqual value: 'WITH example_cte AS (SELECT bar FROM foo) SELECT COUNT(*) FROM example_cte', scopes: ['source.python', scope]
-  expect(tokens[2][0]).toEqual value: '\'', scopes: ['source.python', scope, 'punctuation.definition.string.end.python']
+    expect(tokens[0][0]).toEqual value: '\'', scopes: ['source.python', scope, 'punctuation.definition.string.begin.python']
+    expect(tokens[1][0]).toEqual value: 'WITH example_cte AS (SELECT bar FROM foo) SELECT COUNT(*) FROM example_cte', scopes: ['source.python', scope]
+    expect(tokens[2][0]).toEqual value: '\'', scopes: ['source.python', scope, 'punctuation.definition.string.end.python']

--- a/spec/python-spec.coffee
+++ b/spec/python-spec.coffee
@@ -327,3 +327,11 @@ describe "Python grammar", ->
       expect(tokens[7][0]).toEqual value: 'SELECT COUNT(*)', scopes: ['source.python', scope]
       expect(tokens[8][0]).toEqual value: 'FROM example_cte', scopes: ['source.python', scope]
       expect(tokens[9][0]).toEqual value: delim, scopes: ['source.python', scope, 'punctuation.definition.string.end.python']
+
+it "tokenizes SQL inline highlighting on single line with a CTE", ->
+
+  tokens = grammar.tokenizeLines('WITH example_cte AS (SELECT bar FROM foo) SELECT COUNT(*) FROM example_cte')
+
+  expect(tokens[0][0]).toEqual value: '\'', scopes: ['source.python', scope, 'punctuation.definition.string.begin.python']
+  expect(tokens[1][0]).toEqual value: 'WITH example_cte AS (SELECT bar FROM foo) SELECT COUNT(*) FROM example_cte', scopes: ['source.python', scope]
+  expect(tokens[2][0]).toEqual value: '\'', scopes: ['source.python', scope, 'punctuation.definition.string.end.python']

--- a/spec/python-spec.coffee
+++ b/spec/python-spec.coffee
@@ -329,8 +329,9 @@ describe "Python grammar", ->
 
   it "tokenizes SQL inline highlighting on single line with a CTE", ->
 
-    tokens = grammar.tokenizeLines('WITH example_cte AS (SELECT bar FROM foo) SELECT COUNT(*) FROM example_cte')
+    tokens = grammar.tokenizeLines('\'WITH example_cte AS (SELECT bar FROM foo) SELECT COUNT(*) FROM example_cte\'')
+    console.log(tokens)
 
-    expect(tokens[0][0]).toEqual value: '\'', scopes: ['source.python', scope, 'punctuation.definition.string.begin.python']
-    expect(tokens[1][0]).toEqual value: 'WITH example_cte AS (SELECT bar FROM foo) SELECT COUNT(*) FROM example_cte', scopes: ['source.python', scope]
-    expect(tokens[2][0]).toEqual value: '\'', scopes: ['source.python', scope, 'punctuation.definition.string.end.python']
+    expect(tokens[0][0]).toEqual value: '\'', scopes: ['source.python', 'string.quoted.single.single-line.python', 'punctuation.definition.string.begin.python']
+    expect(tokens[0][1]).toEqual value: 'WITH example_cte AS (SELECT bar FROM foo) SELECT COUNT(*) FROM example_cte', scopes: ['source.python', 'string.quoted.single.single-line.python']
+    expect(tokens[0][2]).toEqual value: '\'', scopes: ['source.python', 'string.quoted.single.single-line.python', 'punctuation.definition.string.end.python']

--- a/spec/python-spec.coffee
+++ b/spec/python-spec.coffee
@@ -303,21 +303,27 @@ describe "Python grammar", ->
       "string.quoted.double.block.sql.python": '"""'
       "string.quoted.single.block.sql.python": "'''"
 
-    for scope, delim in delimsByScope
-      tokens = grammar.tokenizeLines(
-        delim +
-        'WITH example_cte AS (
-        SELECT      bar
-        FROM        foo
-        GROUP BY    bar
+    for scope, delim of delimsByScope
+      tokens = grammar.tokenizeLines("""
+        #{delim}
+        WITH example_cte AS (
+        SELECT bar
+        FROM foo
+        GROUP BY bar
         )
 
-        SELECT      COUNT(*)
-        FROM        example_cte'
-        + delim
-      )
+        SELECT COUNT(*)
+        FROM example_cte
+        #{delim}
+      """)
 
       expect(tokens[0][0]).toEqual value: delim, scopes: ['source.python', scope, 'punctuation.definition.string.begin.python']
-      expect(tokens[1][0]).toEqual value: 'SELECT bar', scopes: ['source.python', scope]
-      expect(tokens[2][0]).toEqual value: 'FROM foo', scopes: ['source.python', scope]
-      expect(tokens[3][0]).toEqual value: delim, scopes: ['source.python', scope, 'punctuation.definition.string.end.python']
+      expect(tokens[1][0]).toEqual value: 'WITH example_cte AS (', scopes: ['source.python', scope]
+      expect(tokens[2][0]).toEqual value: 'SELECT bar', scopes: ['source.python', scope]
+      expect(tokens[3][0]).toEqual value: 'FROM foo', scopes: ['source.python', scope]
+      expect(tokens[4][0]).toEqual value: 'GROUP BY bar', scopes: ['source.python', scope]
+      expect(tokens[5][0]).toEqual value: ')', scopes: ['source.python', scope]
+      expect(tokens[6][0]).toEqual value: '', scopes: ['source.python', scope]
+      expect(tokens[7][0]).toEqual value: 'SELECT COUNT(*)', scopes: ['source.python', scope]
+      expect(tokens[8][0]).toEqual value: 'FROM example_cte', scopes: ['source.python', scope]
+      expect(tokens[9][0]).toEqual value: delim, scopes: ['source.python', scope, 'punctuation.definition.string.end.python']

--- a/spec/python-spec.coffee
+++ b/spec/python-spec.coffee
@@ -316,7 +316,7 @@ describe "Python grammar", ->
         FROM        example_cte'
         + delim
       )
-      print(tokens)
+
       expect(tokens[0][0]).toEqual value: delim, scopes: ['source.python', scope, 'punctuation.definition.string.begin.python']
       expect(tokens[1][0]).toEqual value: 'SELECT bar', scopes: ['source.python', scope]
       expect(tokens[2][0]).toEqual value: 'FROM foo', scopes: ['source.python', scope]

--- a/spec/python-spec.coffee
+++ b/spec/python-spec.coffee
@@ -296,3 +296,28 @@ describe "Python grammar", ->
       expect(tokens[1][0]).toEqual value: 'SELECT bar', scopes: ['source.python', scope]
       expect(tokens[2][0]).toEqual value: 'FROM foo', scopes: ['source.python', scope]
       expect(tokens[3][0]).toEqual value: delim, scopes: ['source.python', scope, 'punctuation.definition.string.end.python']
+
+
+  it "tokenizes SQL inline highlighting on blocks with a CTE", ->
+    delimsByScope =
+      "string.quoted.double.block.sql.python": '"""'
+      "string.quoted.single.block.sql.python": "'''"
+
+    for scope, delim in delimsByScope
+      tokens = grammar.tokenizeLines(
+        delim +
+        'WITH example_cte AS (
+        SELECT      bar
+        FROM        foo
+        GROUP BY    bar
+        )
+
+        SELECT      COUNT(*)
+        FROM        example_cte'
+        + delim
+      )
+      print(tokens)
+      expect(tokens[0][0]).toEqual value: delim, scopes: ['source.python', scope, 'punctuation.definition.string.begin.python']
+      expect(tokens[1][0]).toEqual value: 'SELECT bar', scopes: ['source.python', scope]
+      expect(tokens[2][0]).toEqual value: 'FROM foo', scopes: ['source.python', scope]
+      expect(tokens[3][0]).toEqual value: delim, scopes: ['source.python', scope, 'punctuation.definition.string.end.python']

--- a/spec/python-spec.coffee
+++ b/spec/python-spec.coffee
@@ -329,9 +329,8 @@ describe "Python grammar", ->
 
   it "tokenizes SQL inline highlighting on single line with a CTE", ->
 
-    tokens = grammar.tokenizeLines('\'WITH example_cte AS (SELECT bar FROM foo) SELECT COUNT(*) FROM example_cte\'')
-    console.log(tokens)
+    {tokens} = grammar.tokenizeLine('\'WITH example_cte AS (SELECT bar FROM foo) SELECT COUNT(*) FROM example_cte\'')
 
-    expect(tokens[0][0]).toEqual value: '\'', scopes: ['source.python', 'string.quoted.single.single-line.python', 'punctuation.definition.string.begin.python']
-    expect(tokens[0][1]).toEqual value: 'WITH example_cte AS (SELECT bar FROM foo) SELECT COUNT(*) FROM example_cte', scopes: ['source.python', 'string.quoted.single.single-line.python']
-    expect(tokens[0][2]).toEqual value: '\'', scopes: ['source.python', 'string.quoted.single.single-line.python', 'punctuation.definition.string.end.python']
+    expect(tokens[0]).toEqual value: '\'', scopes: ['source.python', 'string.quoted.single.single-line.python', 'punctuation.definition.string.begin.python']
+    expect(tokens[1]).toEqual value: 'WITH example_cte AS (SELECT bar FROM foo) SELECT COUNT(*) FROM example_cte', scopes: ['source.python', 'string.quoted.single.single-line.python']
+    expect(tokens[2]).toEqual value: '\'', scopes: ['source.python', 'string.quoted.single.single-line.python', 'punctuation.definition.string.end.python']


### PR DESCRIPTION
This looks for SQL queries which being with the `WITH` statement, which signals a Common Table Expression.

I’m confident the test case I added to the spec is not correct, but attempting to run it in Atom via View>Developer>Run Package Specs passed. I welcome any suggestions to improve the test case or pointers to make sure it’s running correctly within Atom.


Fixes #102