### PR TITLE
Adding Python3 grammar

### DIFF
--- a/grammars/python3.cson
+++ b/grammars/python3.cson
@@ -548,8 +548,11 @@ repository:
             name: 'punctuation.definition.string.end.python3'
           '2':
             name: 'meta.empty-string.double.python3'
-        name: 'string.quoted.double.block.bytes-raw.python3'
+        name: 'string.quoted.double.block.raw-bytes.python3'
         patterns: [
+          {
+            include: '#constant_placeholder_printf'
+          }
           {
             include: '#regular_expressions'
           }
@@ -593,8 +596,14 @@ repository:
             name: 'punctuation.definition.string.end.python3'
           '2':
             name: 'meta.empty-string.double.python3'
-        name: 'string.quoted.double.block.unicode-raw.python3'
+        name: 'string.quoted.double.block.raw-unicode.python3'
         patterns: [
+          {
+            include: '#constant_placeholder_printf'
+          }
+          {
+            include: '#constant_placeholder_format'
+          }
           {
             include: '#regular_expressions'
           }
@@ -631,35 +640,21 @@ repository:
         ]
       }
       {
-        comment: 'double quoted bytes-raw string'
-        begin: '([bB][rR]|[rR][bB])(")'
-        beginCaptures:
+        comment: 'bytes double-quoted raw string'
+        match: '(?m)([rR][bB]|[bB][rR])(")((?:[^"\\\\]|\\\\.)*)(")'
+        captures:
           '1':
             name: 'storage.type.string.python3'
           '2':
             name: 'punctuation.definition.string.begin.python3'
-        end: '((?<=")(")|")|(\\n)'
-        endCaptures:
-          '1':
-            name: 'punctuation.definition.string.end.python3'
-          '2':
-            name: 'meta.empty-string.double.python3'
           '3':
-            name: 'invalid.illegal.unclosed-string.python3'
-        name: 'string.quoted.double.single-line.bytes-raw.python3'
-        patterns: [
-          {
-            match: '(\\\\\\n)|(\\\\")'
-            captures:
-              '1':
-                name: 'constant.character.escape.newline.python3'
-              '2':
-                name: 'constant.character.escape.double-quote.python3'
-          }
-          {
-            include: '#regular_expressions'
-          }
-        ]
+            patterns: [
+              {include: '#constant_placeholder_printf'}
+              {include: '#regular_expressions'}
+            ]
+          '4':
+            name: 'punctuation.definition.string.end.python3'
+        name: 'string.quoted.double.single-line.raw-bytes.python3'
       }
       {
         comment: 'double quoted bytes string'
@@ -688,35 +683,21 @@ repository:
         ]
       }
       {
-        comment: 'double quoted unicode-raw string'
-        begin: '([rR])(")'
-        beginCaptures:
+        comment: 'unicode double-quoted raw string'
+        match: '(?m)([rR])(")((?:[^"\\\\]|\\\\.)*)(")'
+        captures:
           '1':
             name: 'storage.type.string.python3'
           '2':
             name: 'punctuation.definition.string.begin.python3'
-        end: '((?<=")(")|")|(\\n)'
-        endCaptures:
-          '1':
-            name: 'punctuation.definition.string.end.python3'
-          '2':
-            name: 'meta.empty-string.double.python3'
           '3':
-            name: 'invalid.illegal.unclosed-string.python3'
-        name: 'string.quoted.double.single-line.unicode-raw.python3'
-        patterns: [
-          {
-            match: '(\\\\\\n)|(\\\\")'
-            captures:
-              '1':
-                name: 'constant.character.escape.newline.python3'
-              '2':
-                name: 'constant.character.escape.double-quote.python3'
-          }
-          {
-            include: '#regular_expressions'
-          }
-        ]
+            patterns: [
+              {include: '#constant_placeholder_printf'}
+              {include: '#regular_expressions'}
+            ]
+          '4':
+            name: 'punctuation.definition.string.end.python3'
+        name: 'string.quoted.double.single-line.raw-unicode.python3'
       }
       {
         comment: 'double quoted unicode string'
@@ -768,8 +749,11 @@ repository:
             name: 'punctuation.definition.string.end.python3'
           '2':
             name: 'meta.empty-string.single.python3'
-        name: 'string.quoted.single.block.bytes-raw.python3'
+        name: 'string.quoted.single.block.raw-bytes.python3'
         patterns: [
+          {
+            include: '#constant_placeholder_printf'
+          }
           {
             include: '#regular_expressions'
           }
@@ -813,8 +797,14 @@ repository:
             name: 'punctuation.definition.string.end.python3'
           '2':
             name: 'meta.empty-string.single.python3'
-        name: 'string.quoted.single.block.unicode-raw.python3'
+        name: 'string.quoted.single.block.raw-unicode.python3'
         patterns: [
+          {
+            include: '#constant_placeholder_printf'
+          }
+          {
+            include: '#constant_placeholder_format'
+          }
           {
             include: '#regular_expressions'
           }
@@ -851,35 +841,21 @@ repository:
         ]
       }
       {
-        comment: 'single quoted bytes-raw string'
-        begin: '([bB][rR]|[rR][bB])(\')'
-        beginCaptures:
+        comment: 'bytes single-quoted raw string'
+        match: '(?m)([rR][bB]|[bB][rR])(\')((?:[^\'\\\\]|\\\\.)*)(\')'
+        captures:
           '1':
             name: 'storage.type.string.python3'
           '2':
             name: 'punctuation.definition.string.begin.python3'
-        end: '((?<=\')(\')|\')|(\\n)'
-        endCaptures:
-          '1':
-            name: 'punctuation.definition.string.end.python3'
-          '2':
-            name: 'meta.empty-string.single.python3'
           '3':
-            name: 'invalid.illegal.unclosed-string.python3'
-        name: 'string.quoted.single.single-line.bytes-raw.python3'
-        patterns: [
-          {
-            match: '(\\\\\\n)|(\\\\\')'
-            captures:
-              '1':
-                name: 'constant.character.escape.newline.python3'
-              '2':
-                name: 'constant.character.escape.double-quote.python3'
-          }
-          {
-            include: '#regular_expressions'
-          }
-        ]
+            patterns: [
+              {include: '#constant_placeholder_printf'}
+              {include: '#regular_expressions'}
+            ]
+          '4':
+            name: 'punctuation.definition.string.end.python3'
+        name: 'string.quoted.single.single-line.raw-bytes.python3'
       }
       {
         comment: 'single quoted bytes string'
@@ -908,35 +884,21 @@ repository:
         ]
       }
       {
-        comment: 'single quoted unicode-raw string'
-        begin: '([rR])(\')'
-        beginCaptures:
+        comment: 'unicode single-quoted raw string'
+        match: '(?m)([rR])(\')((?:[^\'\\\\]|\\\\.)*)(\')'
+        captures:
           '1':
             name: 'storage.type.string.python3'
           '2':
             name: 'punctuation.definition.string.begin.python3'
-        end: '((?<=\')(\')|\')|(\\n)'
-        endCaptures:
-          '1':
-            name: 'punctuation.definition.string.end.python3'
-          '2':
-            name: 'meta.empty-string.single.python3'
           '3':
-            name: 'invalid.illegal.unclosed-string.python3'
-        name: 'string.quoted.single.single-line.unicode-raw.python3'
-        patterns: [
-          {
-            match: '(\\\\\\n)|(\\\\\')'
-            captures:
-              '1':
-                name: 'constant.character.escape.newline.python3'
-              '2':
-                name: 'constant.character.escape.double-quote.python3'
-          }
-          {
-            include: '#regular_expressions'
-          }
-        ]
+            patterns: [
+              {include: '#constant_placeholder_printf'}
+              {include: '#regular_expressions'}
+            ]
+          '4':
+            name: 'punctuation.definition.string.end.python3'
+        name: 'string.quoted.single.single-line.raw-unicode.python3'
       }
       {
         comment: 'single quoted unicode string'
@@ -1332,110 +1294,110 @@ patterns: [
   {
     include: '#language_variables'
   }
-  # {
-  #   begin: '(\\()'
-  #   end: '(\\))'
-  #   patterns: [
-  #     {
-  #       include: '$self'
-  #     }
-  #   ]
-  # }
-  # {
-  #   captures:
-  #     '1':
-  #       name: 'punctuation.definition.list.begin.python3'
-  #     '2':
-  #       name: 'meta.empty-list.python3'
-  #     '3':
-  #       name: 'punctuation.definition.list.end.python3'
-  #   match: '(\\[)(\\s*(\\]))\\b'
-  # }
-  # {
-  #   begin: '(\\[)'
-  #   beginCaptures:
-  #     '1':
-  #       name: 'punctuation.definition.list.begin.python3'
-  #   end: '(\\])'
-  #   endCaptures:
-  #     '1':
-  #       name: 'punctuation.definition.list.end.python3'
-  #   name: 'meta.structure.list.python3'
-  #   patterns: [
-  #     {
-  #       begin: '(?<=\\[|\\,)\\s*(?![\\],])'
-  #       contentName: 'meta.structure.list.item.python3'
-  #       end: '\\s*(?:(,)|(?=\\]))'
-  #       endCaptures:
-  #         '1':
-  #           name: 'punctuation.separator.list.python3'
-  #       patterns: [
-  #         {
-  #           include: '$self'
-  #         }
-  #       ]
-  #     }
-  #   ]
-  # }
-  # {
-  #   captures:
-  #     '1':
-  #       name: 'punctuation.definition.tuple.begin.python3'
-  #     '2':
-  #       name: 'meta.empty-tuple.python3'
-  #     '3':
-  #       name: 'punctuation.definition.tuple.end.python3'
-  #   match: '(\\()(\\s*(\\)))'
-  #   name: 'meta.structure.tuple.python3'
-  # }
-  # {
-  #   captures:
-  #     '1':
-  #       name: 'punctuation.definition.dictionary.begin.python3'
-  #     '2':
-  #       name: 'meta.empty-dictionary.python3'
-  #     '3':
-  #       name: 'punctuation.definition.dictionary.end.python3'
-  #   match: '(\\{)(\\s*(\\}))'
-  #   name: 'meta.structure.dictionary.python3'
-  # }
-  # {
-  #   begin: '(\\{)'
-  #   beginCaptures:
-  #     '1':
-  #       name: 'punctuation.definition.dictionary.begin.python3'
-  #   end: '(\\})'
-  #   endCaptures:
-  #     '1':
-  #       name: 'punctuation.definition.dictionary.end.python3'
-  #   name: 'meta.structure.dictionary.python3'
-  #   patterns: [
-  #     {
-  #       begin: '(?<=\\{|\\,|^)\\s*(?![\\},])'
-  #       contentName: 'meta.structure.dictionary.key.python3'
-  #       end: '\\s*(?:(?=\\})|(\\:))'
-  #       endCaptures:
-  #         '1':
-  #           name: 'punctuation.separator.valuepair.dictionary.python3'
-  #       patterns: [
-  #         {
-  #           include: '$self'
-  #         }
-  #       ]
-  #     }
-  #     {
-  #       begin: '(?<=\\:|^)\\s*'
-  #       contentName: 'meta.structure.dictionary.value.python3'
-  #       end: '\\s*(?:(?=\\})|(,))'
-  #       endCaptures:
-  #         '1':
-  #           name: 'punctuation.separator.dictionary.python3'
-  #       patterns: [
-  #         {
-  #           include: '$self'
-  #         }
-  #       ]
-  #     }
-  #   ]
-  # }
+  {
+    begin: '(\\()'
+    end: '(\\))'
+    patterns: [
+      {
+        include: '$self'
+      }
+    ]
+  }
+  {
+    captures:
+      '1':
+        name: 'punctuation.definition.list.begin.python3'
+      '2':
+        name: 'meta.empty-list.python3'
+      '3':
+        name: 'punctuation.definition.list.end.python3'
+    match: '(\\[)(\\s*(\\]))\\b'
+  }
+  {
+    begin: '(\\[)'
+    beginCaptures:
+      '1':
+        name: 'punctuation.definition.list.begin.python3'
+    end: '(\\])'
+    endCaptures:
+      '1':
+        name: 'punctuation.definition.list.end.python3'
+    name: 'meta.structure.list.python3'
+    patterns: [
+      {
+        begin: '(?<=\\[|\\,)\\s*(?![\\],])'
+        contentName: 'meta.structure.list.item.python3'
+        end: '\\s*(?:(,)|(?=\\]))'
+        endCaptures:
+          '1':
+            name: 'punctuation.separator.list.python3'
+        patterns: [
+          {
+            include: '$self'
+          }
+        ]
+      }
+    ]
+  }
+  {
+    captures:
+      '1':
+        name: 'punctuation.definition.tuple.begin.python3'
+      '2':
+        name: 'meta.empty-tuple.python3'
+      '3':
+        name: 'punctuation.definition.tuple.end.python3'
+    match: '(\\()(\\s*(\\)))'
+    name: 'meta.structure.tuple.python3'
+  }
+  {
+    captures:
+      '1':
+        name: 'punctuation.definition.dictionary.begin.python3'
+      '2':
+        name: 'meta.empty-dictionary.python3'
+      '3':
+        name: 'punctuation.definition.dictionary.end.python3'
+    match: '(\\{)(\\s*(\\}))'
+    name: 'meta.structure.dictionary.python3'
+  }
+  {
+    begin: '(\\{)'
+    beginCaptures:
+      '1':
+        name: 'punctuation.definition.dictionary.begin.python3'
+    end: '(\\})'
+    endCaptures:
+      '1':
+        name: 'punctuation.definition.dictionary.end.python3'
+    name: 'meta.structure.dictionary.python3'
+    patterns: [
+      {
+        begin: '(?<=\\{|\\,|^)\\s*(?![\\},])'
+        contentName: 'meta.structure.dictionary.key.python3'
+        end: '\\s*(?:(?=\\})|(\\:))'
+        endCaptures:
+          '1':
+            name: 'punctuation.separator.valuepair.dictionary.python3'
+        patterns: [
+          {
+            include: '$self'
+          }
+        ]
+      }
+      {
+        begin: '(?<=\\:|^)\\s*'
+        contentName: 'meta.structure.dictionary.value.python3'
+        end: '\\s*(?:(?=\\})|(,))'
+        endCaptures:
+          '1':
+            name: 'punctuation.separator.dictionary.python3'
+        patterns: [
+          {
+            include: '$self'
+          }
+        ]
+      }
+    ]
+  }
 ]

--- a/grammars/python3.cson
+++ b/grammars/python3.cson
@@ -1,4 +1,4 @@
-scopeName: 'source.python3'
+scopeName: 'source.python.3'
 name: 'Python3'
 fileTypes: [
   'cpy'
@@ -28,7 +28,7 @@ repository:
       |sum|super|vars|zip|__import__
       )\\b
       '''
-    name: 'support.function.builtin.python3'
+    name: 'support.function.builtin.python.3'
 
   builtin_types:
     match: '''
@@ -37,40 +37,36 @@ repository:
       |object|range|set|slice|str|tuple
       )\\b
       '''
-    name: 'support.type.python3'
+    name: 'support.type.python.3'
 
   builtin_exceptions:
     match: '''
       (?x)\\b(
       (Base)?Exception
-      |(Is|Not)ADirectory|(Arithmetic|Assertion|Attribute|BlockingIO|BrokenPipe
+      |((Is|Not)ADirectory|Arithmetic|Assertion|Attribute|BlockingIO|BrokenPipe
       |Buffer|ChildProcess|Connection(Aborted|Refused|Reset)?|EOF
       |File(Exists|NotFound)|FloatingPoint|Import|Indentation|Index
       |InterruptedError|Key|(Process)?Lookup|Memory|Name|NotImplemented|OS
       |Overflow|PermissionError|Recursion|Runtime|Syntax|System|Tab|Timeout
       |Type|UnboundLocal|Unicode(Encode|Decode|Translate)?|Value
       |ZeroDivision)Error
-      |(User|Deprecation|PendingDeprecation|Syntax|Runtime|Import|Unicode|Bytes
+      |(User|(Pending)?Deprecation|Syntax|Runtime|Import|Unicode|Bytes
       |Resource)Warning
       |GeneratorExit|KeyboradInterrupt|StopIteration|StopAsyncIteration
       |SytemExit
       )\\b
       '''
-    name: 'support.type.exception.python3'
-
-  # constant_placeholder:
-  #   match: '(?i:(%(\\([a-z_]+\\))?#?0?\\-?[ ]?\\+?([0-9]*|\\*)(\\.([0-9]*|\\*))?([hL][a-z]|[a-z%]))|(\\{([!\\[\\].:\\w ]+)?\\}))'
-  #   name: 'constant.other.placeholder.python3'
+    name: 'support.type.exception.python.3'
 
   constant_placeholder_printf:
     patterns: [
       {
         match: '%%'
-        name: 'constant.other.placeholder-escape.printf.python3'
+        name: 'constant.other.placeholder-escape.printf.python.3'
       }
       {
         match: '%(\\(\\w+\\))?#?0?\\-?[ ]?\\+?([0-9]*|\\*)(\\.([0-9]*|\\*))?([hlL][a-z]|[a-z%])'
-        name: 'constant.other.placeholder.printf.python3'
+        name: 'constant.other.placeholder.printf.python.3'
       }
     ]
 
@@ -78,11 +74,11 @@ repository:
     patterns: [
       {
         match: '\\{\\{|\\}\\}'
-        name: 'constant.other.placeholder-escape.format.python3'
+        name: 'constant.other.placeholder-escape.format.python.3'
       }
       {
         match: '\\{([!\\[\\].:\\w ]+)?\\}'
-        name: 'constant.other.placeholder.format.python3'
+        name: 'constant.other.placeholder.format.python.3'
       }
     ]
 
@@ -91,7 +87,7 @@ repository:
       {
         begin: '^\\s*(?=([uU]|[rR][bB]?|[bB][rR]?)?""")'
         end: '(?<=""")'
-        name: 'comment.block.python3'
+        name: 'comment.block.python.3'
         patterns: [
           {
             include: '#string_quoted_double'
@@ -101,7 +97,7 @@ repository:
       {
         begin: '^\\s*(?=([uU]|[rR][bB]?|[bB][rR]?)?\'\'\')'
         end: '(?<=\'\'\')'
-        name: 'comment.block.python3'
+        name: 'comment.block.python.3'
         patterns: [
           {
             include: '#string_quoted_single'
@@ -114,16 +110,16 @@ repository:
     begin: '(^[ \\t]+)?(?=#)'
     beginCaptures:
       '1':
-        name: 'punctuation.whitespace.comment.leading.python3'
+        name: 'punctuation.whitespace.comment.leading.python.3'
     end: '(?!\\G)'
     patterns: [
       {
         begin: '#'
         beginCaptures:
           '0':
-            name: 'punctuation.definition.comment.python3'
+            name: 'punctuation.definition.comment.python.3'
         end: '\\n'
-        name: 'comment.line.number-sign.python3'
+        name: 'comment.line.number-sign.python.3'
       }
     ]
 
@@ -212,41 +208,41 @@ repository:
     '''
     captures:
       '1':
-        name: 'constant.character.escape.hex.python3'
+        name: 'constant.character.escape.hex.python.3'
       '2':
-        name: 'constant.character.escape.octal.python3'
+        name: 'constant.character.escape.octal.python.3'
       '3':
-        name: 'constant.character.escape.newline.python3'
+        name: 'constant.character.escape.newline.python.3'
       '4':
-        name: 'constant.character.escape.backlash.python3'
+        name: 'constant.character.escape.backlash.python.3'
       '5':
-        name: 'constant.character.escape.double-quote.python3'
+        name: 'constant.character.escape.double-quote.python.3'
       '6':
-        name: 'constant.character.escape.single-quote.python3'
+        name: 'constant.character.escape.single-quote.python.3'
       '7':
-        name: 'constant.character.escape.bell.python3'
+        name: 'constant.character.escape.bell.python.3'
       '8':
-        name: 'constant.character.escape.backspace.python3'
+        name: 'constant.character.escape.backspace.python.3'
       '9':
-        name: 'constant.character.escape.formfeed.python3'
+        name: 'constant.character.escape.formfeed.python.3'
       '10':
-        name: 'constant.character.escape.linefeed.python3'
+        name: 'constant.character.escape.linefeed.python.3'
       '11':
-        name: 'constant.character.escape.return.python3'
+        name: 'constant.character.escape.return.python.3'
       '12':
-        name: 'constant.character.escape.tab.python3'
+        name: 'constant.character.escape.tab.python.3'
       '13':
-        name: 'constant.character.escape.vertical-tab.python3'
+        name: 'constant.character.escape.vertical-tab.python.3'
 
   escaped_unicode_char:
     match: '(\\\\U[0-9A-Fa-f]{8})|(\\\\u[0-9A-Fa-f]{4})|(\\\\N\\{[a-zA-Z ]+\\})'
     captures:
       '1':
-        name: 'constant.character.escape.unicode.16-bit-hex.python3'
+        name: 'constant.character.escape.unicode.16-bit-hex.python.3'
       '2':
-        name: 'constant.character.escape.unicode.32-bit-hex.python3'
+        name: 'constant.character.escape.unicode.32-bit-hex.python.3'
       '3':
-        name: 'constant.character.escape.unicode.name.python3'
+        name: 'constant.character.escape.unicode.name.python.3'
 
   function_name:
     patterns: [
@@ -276,22 +272,22 @@ repository:
         begin: '^\\s*(?:(async)\\s+)?(def)\\s+(?=[A-Za-z_][A-Za-z0-9_]*\\s*\\()'
         beginCaptures:
           '1':
-            name: 'storage.modifier.coroutine.python3'
+            name: 'storage.modifier.coroutine.python.3'
           '2':
-            name: 'storage.type.function.python3'
+            name: 'storage.type.function.python.3'
         end: '(\\))\\s*(?:(\\:)|(.*$\\n?))'
         endCaptures:
           '1':
-            name: 'punctuation.definition.parameters.end.python3'
+            name: 'punctuation.definition.parameters.end.python.3'
           '2':
-            name: 'punctuation.section.function.begin.python3'
+            name: 'punctuation.section.function.begin.python.3'
           '3':
-            name: 'invalid.illegal.missing-section-begin.python3'
-        name: 'meta.function.python3'
+            name: 'invalid.illegal.missing-section-begin.python.3'
+        name: 'meta.function.python.3'
         patterns: [
           {
             begin: '(?=[A-Za-z_][A-Za-z0-9_]*)'
-            contentName: 'entity.name.function.python3'
+            contentName: 'entity.name.function.python.3'
             end: '(?![A-Za-z0-9_])'
             patterns: [
               {
@@ -303,8 +299,8 @@ repository:
             begin: '(\\()'
             beginCaptures:
               '1':
-                name: 'punctuation.definition.parameters.begin.python3'
-            contentName: 'meta.function.parameters.python3'
+                name: 'punctuation.definition.parameters.begin.python.3'
+            contentName: 'meta.function.parameters.python.3'
             end: '(?=\\)\\s*\\:)'
             patterns: [
               {
@@ -316,9 +312,9 @@ repository:
               {
                 captures:
                   '1':
-                    name: 'variable.parameter.function.python3'
+                    name: 'variable.parameter.function.python.3'
                   '2':
-                    name: 'punctuation.separator.parameters.python3'
+                    name: 'punctuation.separator.parameters.python.3'
                 match: '\\b([a-zA-Z_][a-zA-Z_0-9]*)\\s*(?:(,)|(?=[\\n\\)]))'
               }
             ]
@@ -329,18 +325,18 @@ repository:
         begin: '^\\s*(?:(async)\\s+)?(def)\\s+(?=[A-Za-z_][A-Za-z0-9_]*)'
         beginCaptures:
           '1':
-            name: 'storage.type.function.python3'
+            name: 'storage.type.function.python.3'
         end: '(\\()|\\s*($\\n?|#.*$\\n?)'
         endCaptures:
           '1':
-            name: 'punctuation.definition.parameters.begin.python3'
+            name: 'punctuation.definition.parameters.begin.python.3'
           '2':
-            name: 'invalid.illegal.missing-parameters.python3'
-        name: 'meta.function.python3'
+            name: 'invalid.illegal.missing-parameters.python.3'
+        name: 'meta.function.python.3'
         patterns: [
           {
             begin: '(?=[A-Za-z_][A-Za-z0-9_]*)'
-            contentName: 'entity.name.function.python3'
+            contentName: 'entity.name.function.python.3'
             end: '(?![A-Za-z0-9_])'
             patterns: [
               {
@@ -354,20 +350,20 @@ repository:
         begin: '(lambda)(?=\\s+)'
         beginCaptures:
           '1':
-            name: 'storage.type.function.inline.python3'
+            name: 'storage.type.function.inline.python.3'
         end: '(\\:)'
         endCaptures:
           '1':
-            name: 'punctuation.definition.parameters.end.python3'
+            name: 'punctuation.definition.parameters.end.python.3'
           '2':
-            name: 'punctuation.section.function.begin.python3'
+            name: 'punctuation.section.function.begin.python.3'
           '3':
-            name: 'invalid.illegal.missing-section-begin.python3'
-        name: 'meta.function.inline.python3'
+            name: 'invalid.illegal.missing-section-begin.python.3'
+        name: 'meta.function.inline.python.3'
         patterns: [
           {
             begin: '\\s+'
-            contentName: 'meta.function.inline.parameters.python3'
+            contentName: 'meta.function.inline.parameters.python.3'
             end: '(?=\\:)'
             patterns: [
               {
@@ -376,9 +372,9 @@ repository:
               {
                 captures:
                   '1':
-                    name: 'variable.parameter.function.python3'
+                    name: 'variable.parameter.function.python.3'
                   '2':
-                    name: 'punctuation.separator.parameters.python3'
+                    name: 'punctuation.separator.parameters.python.3'
                 match: '\\b([a-zA-Z_][a-zA-Z_0-9]*)\\s*(?:(,)|(?=[\\n\\)\\:]))'
               }
             ]
@@ -391,15 +387,15 @@ repository:
         end: '(\\))'
         endCaptures:
           '1':
-            name: 'punctuation.definition.arguments.end.python3'
-        name: 'meta.function.decorator.python3'
+            name: 'punctuation.definition.arguments.end.python.3'
+        name: 'meta.function.decorator.python.3'
         patterns: [
           {
             begin: '(?=(@)\\s*[A-Za-z_][A-Za-z0-9_]*(?:\\.[A-Za-z_][A-Za-z0-9_]*)*\\s*\\()'
             beginCaptures:
               '1':
-                name: 'punctuation.definition.decorator.python3'
-            contentName: 'entity.name.function.decorator.python3'
+                name: 'punctuation.definition.decorator.python.3'
+            contentName: 'entity.name.function.decorator.python.3'
             end: '(?=\\s*\\()'
             patterns: [
               {
@@ -411,8 +407,8 @@ repository:
             begin: '(\\()'
             beginCaptures:
               '1':
-                name: 'punctuation.definition.arguments.begin.python3'
-            contentName: 'meta.function.decorator.arguments.python3'
+                name: 'punctuation.definition.arguments.begin.python.3'
+            contentName: 'meta.function.decorator.arguments.python.3'
             end: '(?=\\))'
             patterns: [
               {
@@ -427,15 +423,15 @@ repository:
       }
       {
         begin: '^\\s*(?=@[A-Za-z_][A-Za-z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z_0-9]*)*)'
-        contentName: 'entity.name.function.decorator.python3'
+        contentName: 'entity.name.function.decorator.python.3'
         end: '(?=\\s|$\\n?|#)'
-        name: 'meta.function.decorator.python3'
+        name: 'meta.function.decorator.python.3'
         patterns: [
           {
             begin: '(?=(@)\\s*[A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)*)'
             beginCaptures:
               '1':
-                name: 'punctuation.definition.decorator.python3'
+                name: 'punctuation.definition.decorator.python.3'
             end: '(?=\\s|$\\n?|#)'
             patterns: [
               {
@@ -458,19 +454,19 @@ repository:
     |return|try|while|with|yield
     )\\b
     '''
-    name: 'invalid.illegal.name.python3'
+    name: 'invalid.illegal.name.python.3'
 
   keyword_arguments:
     begin: '\\b([a-zA-Z_][a-zA-Z_0-9]*)\\s*(=)(?!=)'
     beginCaptures:
       '1':
-        name: 'variable.parameter.function.python3'
+        name: 'variable.parameter.function.python.3'
       '2':
-        name: 'keyword.operator.assignment.python3'
+        name: 'keyword.operator.assignment.python.3'
     end: '\\s*(?:(,)|(?=$\\n?|[\\)\\:]))'
     endCaptures:
       '1':
-        name: 'punctuation.separator.parameters.python3'
+        name: 'punctuation.separator.parameters.python.3'
     patterns: [
       {
         include: '$self'
@@ -479,15 +475,15 @@ repository:
 
   language_variables:
     match: '\\b(self|cls)\\b'
-    name: 'variable.language.python3'
+    name: 'variable.language.python.3'
 
   line_continuation:
     match: '(\\\\)(.*)$\\n?'
     captures:
       '1':
-        name: 'punctuation.separator.continuation.line.python3'
+        name: 'punctuation.separator.continuation.line.python.3'
       '2':
-        name: 'invalid.illegal.unexpected-text.python3'
+        name: 'invalid.illegal.unexpected-text.python.3'
 
   magic_function_names:
     comment: 'these methods have magic interpretation by python and are generally called indirectly through syntactic constructs'
@@ -512,7 +508,7 @@ repository:
     |aenter|aexit
     )__\\b
     '''
-    name: 'support.function.magic.python3'
+    name: 'support.function.magic.python.3'
 
   magic_variable_names:
     comment: 'magic variables which a class/module may have.'
@@ -521,14 +517,14 @@ repository:
     all|annotations|bases|class|closure|code|debug|dict|doc|file|func|globals|kwdefaults|members|methods|module|name|qualname|self|slots|weakref
     )__\\b
     '''
-    name: 'support.variable.magic.python3'
+    name: 'support.variable.magic.python.3'
 
   regular_expressions:
     comment: 'Changed disabled to 1 to turn off syntax highlighting in “r” strings.'
     disabled: 0
     patterns: [
       {
-        include: 'source.regexp.python3'
+        include: 'source.regexp.python.3'
       }
     ]
 
@@ -539,16 +535,16 @@ repository:
         begin: '([bB][rR]|[rR][bB])(""")'
         beginCaptures:
           '1':
-            name: 'storage.type.string.python3'
+            name: 'storage.type.string.python.3'
           '2':
-            name: 'punctuation.definition.string.begin.python3'
+            name: 'punctuation.definition.string.begin.python.3'
         end: '((?<=""")(")""|""")'
         endCaptures:
           '1':
-            name: 'punctuation.definition.string.end.python3'
+            name: 'punctuation.definition.string.end.python.3'
           '2':
-            name: 'meta.empty-string.double.python3'
-        name: 'string.quoted.double.block.raw-bytes.python3'
+            name: 'meta.empty-string.double.python.3'
+        name: 'string.quoted.double.block.raw-bytes.python.3'
         patterns: [
           {
             include: '#constant_placeholder_printf'
@@ -563,16 +559,16 @@ repository:
         begin: '([bB])(""")'
         beginCaptures:
           '1':
-            name: 'storage.type.string.python3'
+            name: 'storage.type.string.python.3'
           '2':
-            name: 'punctuation.definition.string.begin.python3'
+            name: 'punctuation.definition.string.begin.python.3'
         end: '((?<=""")(")""|""")'
         endCaptures:
           '1':
-            name: 'punctuation.definition.string.end.python3'
+            name: 'punctuation.definition.string.end.python.3'
           '2':
-            name: 'meta.empty-string.double.python3'
-        name: 'string.quoted.double.block.bytes.python3'
+            name: 'meta.empty-string.double.python.3'
+        name: 'string.quoted.double.block.bytes.python.3'
         patterns: [
           {
             include: '#constant_placeholder_printf'
@@ -587,16 +583,16 @@ repository:
         begin: '([rR])(""")'
         beginCaptures:
           '1':
-            name: 'storage.type.string.python3'
+            name: 'storage.type.string.python.3'
           '2':
-            name: 'punctuation.definition.string.begin.python3'
+            name: 'punctuation.definition.string.begin.python.3'
         end: '((?<=""")(")""|""")'
         endCaptures:
           '1':
-            name: 'punctuation.definition.string.end.python3'
+            name: 'punctuation.definition.string.end.python.3'
           '2':
-            name: 'meta.empty-string.double.python3'
-        name: 'string.quoted.double.block.raw-unicode.python3'
+            name: 'meta.empty-string.double.python.3'
+        name: 'string.quoted.double.block.raw-unicode.python.3'
         patterns: [
           {
             include: '#constant_placeholder_printf'
@@ -614,16 +610,16 @@ repository:
         begin: '([uU]?)(""")'
         beginCaptures:
           '1':
-            name: 'storage.type.string.python3'
+            name: 'storage.type.string.python.3'
           '2':
-            name: 'punctuation.definition.string.begin.python3'
+            name: 'punctuation.definition.string.begin.python.3'
         end: '((?<=""")(")""|""")'
         endCaptures:
           '1':
-            name: 'punctuation.definition.string.end.python3'
+            name: 'punctuation.definition.string.end.python.3'
           '2':
-            name: 'meta.empty-string.double.python3'
-        name: 'string.quoted.double.block.unicode.python3'
+            name: 'meta.empty-string.double.python.3'
+        name: 'string.quoted.double.block.unicode.python.3'
         patterns: [
           {
             include: '#constant_placeholder_printf'
@@ -644,35 +640,35 @@ repository:
         match: '(?m)([rR][bB]|[bB][rR])(")((?:[^"\\\\]|\\\\.)*)(")'
         captures:
           '1':
-            name: 'storage.type.string.python3'
+            name: 'storage.type.string.python.3'
           '2':
-            name: 'punctuation.definition.string.begin.python3'
+            name: 'punctuation.definition.string.begin.python.3'
           '3':
             patterns: [
               {include: '#constant_placeholder_printf'}
               {include: '#regular_expressions'}
             ]
           '4':
-            name: 'punctuation.definition.string.end.python3'
-        name: 'string.quoted.double.single-line.raw-bytes.python3'
+            name: 'punctuation.definition.string.end.python.3'
+        name: 'string.quoted.double.single-line.raw-bytes.python.3'
       }
       {
         comment: 'double quoted bytes string'
         begin: '([bB])(")'
         beginCaptures:
           '1':
-            name: 'storage.type.string.python3'
+            name: 'storage.type.string.python.3'
           '2':
-            name: 'punctuation.definition.string.begin.python3'
+            name: 'punctuation.definition.string.begin.python.3'
         end: '((?<=")(")|")|(\\n)'
         endCaptures:
           '1':
-            name: 'punctuation.definition.string.end.python3'
+            name: 'punctuation.definition.string.end.python.3'
           '2':
-            name: 'meta.empty-string.double.python3'
+            name: 'meta.empty-string.double.python.3'
           '3':
-            name: 'invalid.illegal.unclosed-string.python3'
-        name: 'string.quoted.double.single-line.bytes.python3'
+            name: 'invalid.illegal.unclosed-string.python.3'
+        name: 'string.quoted.double.single-line.bytes.python.3'
         patterns: [
           {
             include: '#constant_placeholder_printf'
@@ -687,35 +683,35 @@ repository:
         match: '(?m)([rR])(")((?:[^"\\\\]|\\\\.)*)(")'
         captures:
           '1':
-            name: 'storage.type.string.python3'
+            name: 'storage.type.string.python.3'
           '2':
-            name: 'punctuation.definition.string.begin.python3'
+            name: 'punctuation.definition.string.begin.python.3'
           '3':
             patterns: [
               {include: '#constant_placeholder_printf'}
               {include: '#regular_expressions'}
             ]
           '4':
-            name: 'punctuation.definition.string.end.python3'
-        name: 'string.quoted.double.single-line.raw-unicode.python3'
+            name: 'punctuation.definition.string.end.python.3'
+        name: 'string.quoted.double.single-line.raw-unicode.python.3'
       }
       {
         comment: 'double quoted unicode string'
         begin: '([uU]?)(")'
         beginCaptures:
           '1':
-            name: 'storage.type.string.python3'
+            name: 'storage.type.string.python.3'
           '2':
-            name: 'punctuation.definition.string.begin.python3'
+            name: 'punctuation.definition.string.begin.python.3'
         end: '((?<=")(")|")|(\\n)'
         endCaptures:
           '1':
-            name: 'punctuation.definition.string.end.python3'
+            name: 'punctuation.definition.string.end.python.3'
           '2':
-            name: 'meta.empty-string.double.python3'
+            name: 'meta.empty-string.double.python.3'
           '3':
-            name: 'invalid.illegal.unclosed-string.python3'
-        name: 'string.quoted.double.single-line.unicode.python3'
+            name: 'invalid.illegal.unclosed-string.python.3'
+        name: 'string.quoted.double.single-line.unicode.python.3'
         patterns: [
           {
             include: '#constant_placeholder_printf'
@@ -740,16 +736,16 @@ repository:
         begin: '([bB][rR]|[rR][bB])(\'\'\')'
         beginCaptures:
           '1':
-            name: 'storage.type.string.python3'
+            name: 'storage.type.string.python.3'
           '2':
-            name: 'punctuation.definition.string.begin.python3'
+            name: 'punctuation.definition.string.begin.python.3'
         end: '((?<=\'\'\')(\')\'\'|\'\'\')'
         endCaptures:
           '1':
-            name: 'punctuation.definition.string.end.python3'
+            name: 'punctuation.definition.string.end.python.3'
           '2':
-            name: 'meta.empty-string.single.python3'
-        name: 'string.quoted.single.block.raw-bytes.python3'
+            name: 'meta.empty-string.single.python.3'
+        name: 'string.quoted.single.block.raw-bytes.python.3'
         patterns: [
           {
             include: '#constant_placeholder_printf'
@@ -764,16 +760,16 @@ repository:
         begin: '([bB])(\'\'\')'
         beginCaptures:
           '1':
-            name: 'storage.type.string.python3'
+            name: 'storage.type.string.python.3'
           '2':
-            name: 'punctuation.definition.string.begin.python3'
+            name: 'punctuation.definition.string.begin.python.3'
         end: '((?<=\'\'\')(\')\'\'|\'\'\')'
         endCaptures:
           '1':
-            name: 'punctuation.definition.string.end.python3'
+            name: 'punctuation.definition.string.end.python.3'
           '2':
-            name: 'meta.empty-string.single.python3'
-        name: 'string.quoted.single.block.bytes.python3'
+            name: 'meta.empty-string.single.python.3'
+        name: 'string.quoted.single.block.bytes.python.3'
         patterns: [
           {
             include: '#constant_placeholder_printf'
@@ -788,16 +784,16 @@ repository:
         begin: '([rR])(\'\'\')'
         beginCaptures:
           '1':
-            name: 'storage.type.string.python3'
+            name: 'storage.type.string.python.3'
           '2':
-            name: 'punctuation.definition.string.begin.python3'
+            name: 'punctuation.definition.string.begin.python.3'
         end: '((?<=\'\'\')(\')\'\'|\'\'\')'
         endCaptures:
           '1':
-            name: 'punctuation.definition.string.end.python3'
+            name: 'punctuation.definition.string.end.python.3'
           '2':
-            name: 'meta.empty-string.single.python3'
-        name: 'string.quoted.single.block.raw-unicode.python3'
+            name: 'meta.empty-string.single.python.3'
+        name: 'string.quoted.single.block.raw-unicode.python.3'
         patterns: [
           {
             include: '#constant_placeholder_printf'
@@ -815,16 +811,16 @@ repository:
         begin: '([uU]?)(\'\'\')'
         beginCaptures:
           '1':
-            name: 'storage.type.string.python3'
+            name: 'storage.type.string.python.3'
           '2':
-            name: 'punctuation.definition.string.begin.python3'
+            name: 'punctuation.definition.string.begin.python.3'
         end: '((?<=\'\'\')(\')\'\'|\'\'\')'
         endCaptures:
           '1':
-            name: 'punctuation.definition.string.end.python3'
+            name: 'punctuation.definition.string.end.python.3'
           '2':
-            name: 'meta.empty-string.single.python3'
-        name: 'string.quoted.single.block.unicode.python3'
+            name: 'meta.empty-string.single.python.3'
+        name: 'string.quoted.single.block.unicode.python.3'
         patterns: [
           {
             include: '#constant_placeholder_printf'
@@ -845,35 +841,35 @@ repository:
         match: '(?m)([rR][bB]|[bB][rR])(\')((?:[^\'\\\\]|\\\\.)*)(\')'
         captures:
           '1':
-            name: 'storage.type.string.python3'
+            name: 'storage.type.string.python.3'
           '2':
-            name: 'punctuation.definition.string.begin.python3'
+            name: 'punctuation.definition.string.begin.python.3'
           '3':
             patterns: [
               {include: '#constant_placeholder_printf'}
               {include: '#regular_expressions'}
             ]
           '4':
-            name: 'punctuation.definition.string.end.python3'
-        name: 'string.quoted.single.single-line.raw-bytes.python3'
+            name: 'punctuation.definition.string.end.python.3'
+        name: 'string.quoted.single.single-line.raw-bytes.python.3'
       }
       {
         comment: 'single quoted bytes string'
         begin: '([bB])(\')'
         beginCaptures:
           '1':
-            name: 'storage.type.string.python3'
+            name: 'storage.type.string.python.3'
           '2':
-            name: 'punctuation.definition.string.begin.python3'
+            name: 'punctuation.definition.string.begin.python.3'
         end: '((?<=\')(\')|\')|(\\n)'
         endCaptures:
           '1':
-            name: 'punctuation.definition.string.end.python3'
+            name: 'punctuation.definition.string.end.python.3'
           '2':
-            name: 'meta.empty-string.single.python3'
+            name: 'meta.empty-string.single.python.3'
           '3':
-            name: 'invalid.illegal.unclosed-string.python3'
-        name: 'string.quoted.single.single-line.bytes.python3'
+            name: 'invalid.illegal.unclosed-string.python.3'
+        name: 'string.quoted.single.single-line.bytes.python.3'
         patterns: [
           {
             include: '#constant_placeholder_printf'
@@ -888,35 +884,35 @@ repository:
         match: '(?m)([rR])(\')((?:[^\'\\\\]|\\\\.)*)(\')'
         captures:
           '1':
-            name: 'storage.type.string.python3'
+            name: 'storage.type.string.python.3'
           '2':
-            name: 'punctuation.definition.string.begin.python3'
+            name: 'punctuation.definition.string.begin.python.3'
           '3':
             patterns: [
               {include: '#constant_placeholder_printf'}
               {include: '#regular_expressions'}
             ]
           '4':
-            name: 'punctuation.definition.string.end.python3'
-        name: 'string.quoted.single.single-line.raw-unicode.python3'
+            name: 'punctuation.definition.string.end.python.3'
+        name: 'string.quoted.single.single-line.raw-unicode.python.3'
       }
       {
         comment: 'single quoted unicode string'
         begin: '([uU]?)(\')'
         beginCaptures:
           '1':
-            name: 'storage.type.string.python3'
+            name: 'storage.type.string.python.3'
           '2':
-            name: 'punctuation.definition.string.begin.python3'
+            name: 'punctuation.definition.string.begin.python.3'
         end: '((?<=\')(\')|\')|(\\n)'
         endCaptures:
           '1':
-            name: 'punctuation.definition.string.end.python3'
+            name: 'punctuation.definition.string.end.python.3'
           '2':
-            name: 'meta.empty-string.single.python3'
+            name: 'meta.empty-string.single.python.3'
           '3':
-            name: 'invalid.illegal.unclosed-string.python3'
-        name: 'string.quoted.single.single-line.unicode.python3'
+            name: 'invalid.illegal.unclosed-string.python.3'
+        name: 'string.quoted.single.single-line.unicode.python.3'
         patterns: [
           {
             include: '#constant_placeholder_printf'
@@ -953,131 +949,131 @@ patterns: [
   }
   {
     match: '\\b(?i:(0x\\h*)L)'
-    name: 'constant.numeric.integer.long.hexadecimal.python3'
+    name: 'constant.numeric.integer.long.hexadecimal.python.3'
   }
   {
     match: '\\b(?i:(0x\\h*))'
-    name: 'constant.numeric.integer.hexadecimal.python3'
+    name: 'constant.numeric.integer.hexadecimal.python.3'
   }
   {
     match: '\\b(?i:(0o?[0-7]+)L)'
-    name: 'constant.numeric.integer.long.octal.python3'
+    name: 'constant.numeric.integer.long.octal.python.3'
   }
   {
     match: '\\b(?i:(0o?[0-7]+))'
-    name: 'constant.numeric.integer.octal.python3'
+    name: 'constant.numeric.integer.octal.python.3'
   }
   {
     match: '\\b(?i:(0b[01]+)L)',
-    name: 'constant.numeric.integer.long.binary.python3'
+    name: 'constant.numeric.integer.long.binary.python.3'
   }
   {
     match: '\\b(?i:(0b[01]+))',
-    name: 'constant.numeric.integer.binary.python3'
+    name: 'constant.numeric.integer.binary.python.3'
   }
   {
     match: '\\b(?i:(((\\d+(\\.(?=[^a-zA-Z_])\\d*)?|(?<=[^0-9a-zA-Z_])\\.\\d+)(e[\\-\\+]?\\d+)?))J)'
-    name: 'constant.numeric.complex.python3'
+    name: 'constant.numeric.complex.python.3'
   }
   {
     match: '\\b(?i:(\\d+\\.\\d*(e[\\-\\+]?\\d+)?))(?=[^a-zA-Z_])'
-    name: 'constant.numeric.float.python3'
+    name: 'constant.numeric.float.python.3'
   }
   {
     match: '(?<=[^0-9a-zA-Z_])(?i:(\\.\\d+(e[\\-\\+]?\\d+)?))'
-    name: 'constant.numeric.float.python3'
+    name: 'constant.numeric.float.python.3'
   }
   {
     match: '\\b(?i:(\\d+e[\\-\\+]?\\d+))'
-    name: 'constant.numeric.float.python3'
+    name: 'constant.numeric.float.python.3'
   }
   {
     match: '\\b(?i:([1-9]+[0-9]*|0)L)'
-    name: 'constant.numeric.integer.long.decimal.python3'
+    name: 'constant.numeric.integer.long.decimal.python.3'
   }
   {
     match: '\\b([1-9]+[0-9]*|0)'
-    name: 'constant.numeric.integer.decimal.python3'
+    name: 'constant.numeric.integer.decimal.python.3'
   }
   {
     match: '\\b(global)\\b'
-    name: 'storage.modifier.global.python3'
+    name: 'storage.modifier.global.python.3'
   }
   {
     match: '\\b(nonlocal)\\b'
-    name: 'storage.modifier.nonlocal.python3'
+    name: 'storage.modifier.nonlocal.python.3'
   }
   {
     match: '\\b(async)\\b'
-    name: 'storage.modifier.coroutine.python3'
+    name: 'storage.modifier.coroutine.python.3'
   }
   {
     captures:
       '1':
-        name: 'keyword.control.import.python3'
+        name: 'keyword.control.import.python.3'
       '2':
-        name: 'keyword.control.import.from.python3'
+        name: 'keyword.control.import.from.python.3'
     match: '\\b(?:(import)|(from))\\b'
   }
   {
     comment: 'keywords that delimit flow conditionals'
-    name: 'keyword.control.conditional.python3'
+    name: 'keyword.control.conditional.python.3'
     match: '\\b(if|elif|else)\\b'
   }
   {
     comment: 'keywords that delimit an exception'
-    name: 'keyword.control.exception.python3'
+    name: 'keyword.control.exception.python.3'
     match: '\\b(except|finally|try|raise)\\b'
   }
   {
     comment: 'keywords that delimit loops'
     match: '\\b(for|while)\\b'
-    name: 'keyword.control.repeat.python3'
+    name: 'keyword.control.repeat.python.3'
   }
   {
     comment: 'keywords that alter flow from within a block'
-    name: 'keyword.control.statement.python3'
+    name: 'keyword.control.statement.python.3'
     match: '\\b(with|break|continue|pass|return|yield|await)\\b'
   }
   {
     comment: 'keyword operators that evaluate to True or False'
     match: '\\b(and|in|is|not|or)\\b'
-    name: 'keyword.operator.logical.python3'
+    name: 'keyword.operator.logical.python.3'
   }
   {
     comment: 'keywords that haven\'t fit into other groups (yet).'
     match: '\\b(as|assert|del)\\b'
     captures:
       '1':
-        name: 'keyword.other.python3'
+        name: 'keyword.other.python.3'
   }
   {
     match: '<\\=|>\\=|\\=\\=|<|>|\\!\\='
-    name: 'keyword.operator.comparison.python3'
+    name: 'keyword.operator.comparison.python.3'
   }
   {
     match: '\\+\\=|-\\=|\\*\\=|/\\=|//\\=|%\\=|@=|&\\=|\\|\\=|\\^\\=|>>\\=|<<\\=|\\*\\*\\='
-    name: 'keyword.operator.assignment.augmented.python3'
+    name: 'keyword.operator.assignment.augmented.python.3'
   }
   {
     match: '\\+|\\-|\\*|\\*\\*|/|//|%|@|<<|>>|&|\\||\\^|~'
-    name: 'keyword.operator.arithmetic.python3'
+    name: 'keyword.operator.arithmetic.python.3'
   }
   {
     match: '\\='
-    name: 'keyword.operator.assignment.python3'
+    name: 'keyword.operator.assignment.python.3'
   }
   {
     begin: '^\\s*(class)\\s+(?=[a-zA-Z_][a-zA-Z_0-9]*\\s*\\:)'
     beginCaptures:
       '1':
-        name: 'storage.type.class.python3'
-    contentName: 'entity.name.type.class.python3'
+        name: 'storage.type.class.python.3'
+    contentName: 'entity.name.type.class.python.3'
     end: '\\s*(:)'
     endCaptures:
       '1':
-        name: 'punctuation.section.class.begin.python3'
-    name: 'meta.class.old-style.python3'
+        name: 'punctuation.section.class.begin.python.3'
+    name: 'meta.class.old-style.python.3'
     patterns: [
       {
         include: '#entity_name_class'
@@ -1088,20 +1084,20 @@ patterns: [
     begin: '^\\s*(class)\\s+(?=[a-zA-Z_][a-zA-Z_0-9]*\\s*\\()'
     beginCaptures:
       '1':
-        name: 'storage.type.class.python3'
+        name: 'storage.type.class.python.3'
     end: '(\\))\\s*(?:(\\:)|(.*$\\n?))'
     endCaptures:
       '1':
-        name: 'punctuation.definition.inheritance.end.python3'
+        name: 'punctuation.definition.inheritance.end.python.3'
       '2':
-        name: 'punctuation.section.class.begin.python3'
+        name: 'punctuation.section.class.begin.python.3'
       '3':
-        name: 'invalid.illegal.missing-section-begin.python3'
-    name: 'meta.class.python3'
+        name: 'invalid.illegal.missing-section-begin.python.3'
+    name: 'meta.class.python.3'
     patterns: [
       {
         begin: '(?=[A-Za-z_][A-Za-z0-9_]*)'
-        contentName: 'entity.name.type.class.python3'
+        contentName: 'entity.name.type.class.python.3'
         end: '(?![A-Za-z0-9_])'
         patterns: [
           {
@@ -1113,17 +1109,17 @@ patterns: [
         begin: '(\\()'
         beginCaptures:
           '1':
-            name: 'punctuation.definition.inheritance.begin.python3'
-        contentName: 'meta.class.inheritance.python3'
+            name: 'punctuation.definition.inheritance.begin.python.3'
+        contentName: 'meta.class.inheritance.python.3'
         end: '(?=\\)|:)'
         patterns: [
           {
             begin: '(?<=\\(|,)\\s*'
-            contentName: 'entity.other.inherited-class.python3'
+            contentName: 'entity.other.inherited-class.python.3'
             end: '\\s*(?:(,)|(?=\\)))'
             endCaptures:
               '1':
-                name: 'punctuation.separator.inheritance.python3'
+                name: 'punctuation.separator.inheritance.python.3'
             patterns: [
               {
                 include: '$self'
@@ -1138,18 +1134,18 @@ patterns: [
     begin: '^\\s*(class)\\s+(?=[a-zA-Z_][a-zA-Z_0-9])'
     beginCaptures:
       '1':
-        name: 'storage.type.class.python3'
+        name: 'storage.type.class.python.3'
     end: '(\\()|(\\s*$\\n?|#.*$\\n?)'
     endCaptures:
       '1':
-        name: 'punctuation.definition.inheritance.begin.python3'
+        name: 'punctuation.definition.inheritance.begin.python.3'
       '2':
-        name: 'invalid.illegal.missing-inheritance.python3'
-    name: 'meta.class.python3'
+        name: 'invalid.illegal.missing-inheritance.python.3'
+    name: 'meta.class.python.3'
     patterns: [
       {
         begin: '(?=[A-Za-z_][A-Za-z0-9_]*)'
-        contentName: 'entity.name.type.class.python3'
+        contentName: 'entity.name.type.class.python.3'
         end: '(?![A-Za-z0-9_])'
         patterns: [
           {
@@ -1163,13 +1159,13 @@ patterns: [
     begin: '(?<=\\)|\\])\\s*(\\()'
     beginCaptures:
       '1':
-        name: 'punctuation.definition.arguments.begin.python3'
-    contentName: 'meta.function-call.arguments.python3'
+        name: 'punctuation.definition.arguments.begin.python.3'
+    contentName: 'meta.function-call.arguments.python.3'
     end: '(\\))'
     endCaptures:
       '1':
-        name: 'punctuation.definition.arguments.end.python3'
-    name: 'meta.function-call.python3'
+        name: 'punctuation.definition.arguments.end.python.3'
+    name: 'meta.function-call.python.3'
     patterns: [
       {
         include: '#keyword_arguments'
@@ -1184,8 +1180,8 @@ patterns: [
     end: '(\\))'
     endCaptures:
       '1':
-        name: 'punctuation.definition.arguments.end.python3'
-    name: 'meta.function-call.python3'
+        name: 'punctuation.definition.arguments.end.python.3'
+    name: 'meta.function-call.python.3'
     patterns: [
       {
         begin: '(?=[A-Za-z_][A-Za-z0-9_]*(?:\\.[A-Za-z_][A-Za-z0-9_]*)*\\s*\\()'
@@ -1200,8 +1196,8 @@ patterns: [
         begin: '(\\()'
         beginCaptures:
           '1':
-            name: 'punctuation.definition.arguments.begin.python3'
-        contentName: 'meta.function-call.arguments.python3'
+            name: 'punctuation.definition.arguments.begin.python.3'
+        contentName: 'meta.function-call.arguments.python.3'
         end: '(?=\\))'
         patterns: [
           {
@@ -1219,8 +1215,8 @@ patterns: [
     end: '(\\])'
     endCaptures:
       '1':
-        name: 'punctuation.definition.arguments.end.python3'
-    name: 'meta.item-access.python3'
+        name: 'punctuation.definition.arguments.end.python.3'
+    name: 'meta.item-access.python.3'
     patterns: [
       {
         begin: '(?=[A-Za-z_][A-Za-z0-9_]*(?:\\.[A-Za-z_][A-Za-z0-9_]*)*\\s*\\[)'
@@ -1235,8 +1231,8 @@ patterns: [
         begin: '(\\[)'
         beginCaptures:
           '1':
-            name: 'punctuation.definition.arguments.begin.python3'
-        contentName: 'meta.item-access.arguments.python3'
+            name: 'punctuation.definition.arguments.begin.python.3'
+        contentName: 'meta.item-access.arguments.python.3'
         end: '(?=\\])'
         patterns: [
           {
@@ -1250,13 +1246,13 @@ patterns: [
     begin: '(?<=\\)|\\])\\s+(\\[)'
     beginCaptures:
       '1':
-        name: 'punctuation.definition.arguments.begin.python3'
-    contentName: 'meta.item-access.arguments.python3'
+        name: 'punctuation.definition.arguments.begin.python.3'
+    contentName: 'meta.item-access.arguments.python.3'
     end: '(\\])'
     endCaptures:
       '1':
-        name: 'punctuation.definition.arguments.end.python3'
-    name: 'meta.item-access.python3'
+        name: 'punctuation.definition.arguments.end.python.3'
+    name: 'meta.item-access.python.3'
     patterns: [
       {
         include: '$self'
@@ -1266,13 +1262,13 @@ patterns: [
   {
     captures:
       '1':
-        name: 'storage.type.function.python3'
+        name: 'storage.type.function.python.3'
     match: '\\b(def|lambda)\\b'
   }
   {
     captures:
       '1':
-        name: 'storage.type.class.python3'
+        name: 'storage.type.class.python.3'
     match: '\\b(class)\\b'
   }
   {
@@ -1280,7 +1276,7 @@ patterns: [
   }
   {
     match: '\\b(None|True|False|Ellipsis|NotImplemented)\\b'
-    name: 'constant.language.python3'
+    name: 'constant.language.python.3'
   }
   {
     include: '#string_quoted_single'
@@ -1306,31 +1302,31 @@ patterns: [
   {
     captures:
       '1':
-        name: 'punctuation.definition.list.begin.python3'
+        name: 'punctuation.definition.list.begin.python.3'
       '2':
-        name: 'meta.empty-list.python3'
+        name: 'meta.empty-list.python.3'
       '3':
-        name: 'punctuation.definition.list.end.python3'
+        name: 'punctuation.definition.list.end.python.3'
     match: '(\\[)(\\s*(\\]))\\b'
   }
   {
     begin: '(\\[)'
     beginCaptures:
       '1':
-        name: 'punctuation.definition.list.begin.python3'
+        name: 'punctuation.definition.list.begin.python.3'
     end: '(\\])'
     endCaptures:
       '1':
-        name: 'punctuation.definition.list.end.python3'
-    name: 'meta.structure.list.python3'
+        name: 'punctuation.definition.list.end.python.3'
+    name: 'meta.structure.list.python.3'
     patterns: [
       {
         begin: '(?<=\\[|\\,)\\s*(?![\\],])'
-        contentName: 'meta.structure.list.item.python3'
+        contentName: 'meta.structure.list.item.python.3'
         end: '\\s*(?:(,)|(?=\\]))'
         endCaptures:
           '1':
-            name: 'punctuation.separator.list.python3'
+            name: 'punctuation.separator.list.python.3'
         patterns: [
           {
             include: '$self'
@@ -1342,43 +1338,43 @@ patterns: [
   {
     captures:
       '1':
-        name: 'punctuation.definition.tuple.begin.python3'
+        name: 'punctuation.definition.tuple.begin.python.3'
       '2':
-        name: 'meta.empty-tuple.python3'
+        name: 'meta.empty-tuple.python.3'
       '3':
-        name: 'punctuation.definition.tuple.end.python3'
+        name: 'punctuation.definition.tuple.end.python.3'
     match: '(\\()(\\s*(\\)))'
-    name: 'meta.structure.tuple.python3'
+    name: 'meta.structure.tuple.python.3'
   }
   {
     captures:
       '1':
-        name: 'punctuation.definition.dictionary.begin.python3'
+        name: 'punctuation.definition.dictionary.begin.python.3'
       '2':
-        name: 'meta.empty-dictionary.python3'
+        name: 'meta.empty-dictionary.python.3'
       '3':
-        name: 'punctuation.definition.dictionary.end.python3'
+        name: 'punctuation.definition.dictionary.end.python.3'
     match: '(\\{)(\\s*(\\}))'
-    name: 'meta.structure.dictionary.python3'
+    name: 'meta.structure.dictionary.python.3'
   }
   {
     begin: '(\\{)'
     beginCaptures:
       '1':
-        name: 'punctuation.definition.dictionary.begin.python3'
+        name: 'punctuation.definition.dictionary.begin.python.3'
     end: '(\\})'
     endCaptures:
       '1':
-        name: 'punctuation.definition.dictionary.end.python3'
-    name: 'meta.structure.dictionary.python3'
+        name: 'punctuation.definition.dictionary.end.python.3'
+    name: 'meta.structure.dictionary.python.3'
     patterns: [
       {
         begin: '(?<=\\{|\\,|^)\\s*(?![\\},])'
-        contentName: 'meta.structure.dictionary.key.python3'
+        contentName: 'meta.structure.dictionary.key.python.3'
         end: '\\s*(?:(?=\\})|(\\:))'
         endCaptures:
           '1':
-            name: 'punctuation.separator.valuepair.dictionary.python3'
+            name: 'punctuation.separator.valuepair.dictionary.python.3'
         patterns: [
           {
             include: '$self'
@@ -1387,11 +1383,11 @@ patterns: [
       }
       {
         begin: '(?<=\\:|^)\\s*'
-        contentName: 'meta.structure.dictionary.value.python3'
+        contentName: 'meta.structure.dictionary.value.python.3'
         end: '\\s*(?:(?=\\})|(,))'
         endCaptures:
           '1':
-            name: 'punctuation.separator.dictionary.python3'
+            name: 'punctuation.separator.dictionary.python.3'
         patterns: [
           {
             include: '$self'

--- a/grammars/python3.cson
+++ b/grammars/python3.cson
@@ -387,7 +387,7 @@ repository:
       }
       {
         comment: 'a decorator may be a function call which returns a decorator.'
-        begin: '^\\s*(?=@\\s*[A-Za-z_][A-Za-z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z_0-9]*)*\\s*\\()'
+        begin: '^\\s*(?=@[A-Za-z_][A-Za-z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z_0-9]*)*\\s*\\()'
         end: '(\\))'
         endCaptures:
           '1':
@@ -426,7 +426,7 @@ repository:
         ]
       }
       {
-        begin: '^\\s*(?=@\\s*[A-Za-z_][A-Za-z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z_0-9]*)*)'
+        begin: '^\\s*(?=@[A-Za-z_][A-Za-z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z_0-9]*)*)'
         contentName: 'entity.name.function.decorator.python3'
         end: '(?=\\s|$\\n?|#)'
         name: 'meta.function.decorator.python3'

--- a/grammars/python3.cson
+++ b/grammars/python3.cson
@@ -1,0 +1,1441 @@
+scopeName: 'source.python3'
+name: 'Python3'
+fileTypes: [
+  'cpy'
+  'gyp'
+  'gypi'
+  'kv'
+  'py'
+  'pyw'
+  'rpy'
+  'SConscript'
+  'SConstruct'
+  'Sconstruct'
+  'sconstruct'
+  'Snakefile'
+  'tac'
+  'wsgi'
+]
+firstLineMatch: '^#!/.*\\bpython[\\d\\.]*\\b'
+repository:
+  builtin_functions:
+    match: '''
+      (?x)\\b(
+      abs|all|any|ascii|bin|callable|chr|classmethod|compile|delattr|dir|divmod
+      |enumerate|eval|exec|filter|format|getattr|globals|hasattr|hash|help|hex
+      |id|input|isinstance|issubclass|iter|len|locals|map|max|min|next|oct|open
+      |ord|pow|print|property|repr|reversed|round|setattr|sorted|staticmethod
+      |sum|super|vars|zip|__import__
+      )\\b
+      '''
+    name: 'support.function.builtin.python3'
+
+  builtin_types:
+    match: '''
+      (?x)\\b(
+      bool|bytearray|bytes|complex|dict|float|frozenset|int|list|memoryview
+      |object|range|set|slice|str|tuple
+      )\\b
+      '''
+    name: 'support.type.python3'
+
+  builtin_exceptions:
+    match: '''
+      (?x)\\b(
+      (Base)?Exception
+      |(Is|Not)ADirectory|(Arithmetic|Assertion|Attribute|BlockingIO|BrokenPipe
+      |Buffer|ChildProcess|Connection(Aborted|Refused|Reset)?|EOF
+      |File(Exists|NotFound)|FloatingPoint|Import|Indentation|Index
+      |InterruptedError|Key|(Process)?Lookup|Memory|Name|NotImplemented|OS
+      |Overflow|PermissionError|Recursion|Runtime|Syntax|System|Tab|Timeout
+      |Type|UnboundLocal|Unicode(Encode|Decode|Translate)?|Value
+      |ZeroDivision)Error
+      |(User|Deprecation|PendingDeprecation|Syntax|Runtime|Import|Unicode|Bytes
+      |Resource)Warning
+      |GeneratorExit|KeyboradInterrupt|StopIteration|StopAsyncIteration
+      |SytemExit
+      )\\b
+      '''
+    name: 'support.type.exception.python3'
+
+  # constant_placeholder:
+  #   match: '(?i:(%(\\([a-z_]+\\))?#?0?\\-?[ ]?\\+?([0-9]*|\\*)(\\.([0-9]*|\\*))?([hL][a-z]|[a-z%]))|(\\{([!\\[\\].:\\w ]+)?\\}))'
+  #   name: 'constant.other.placeholder.python3'
+
+  constant_placeholder_printf:
+    patterns: [
+      {
+        match: '%%'
+        name: 'constant.other.placeholder-escape.printf.python3'
+      }
+      {
+        match: '%(\\(\\w+\\))?#?0?\\-?[ ]?\\+?([0-9]*|\\*)(\\.([0-9]*|\\*))?([hlL][a-z]|[a-z%])'
+        name: 'constant.other.placeholder.printf.python3'
+      }
+    ]
+
+  constant_placeholder_format:
+    patterns: [
+      {
+        match: '\\{\\{|\\}\\}'
+        name: 'constant.other.placeholder-escape.format.python3'
+      }
+      {
+        match: '\\{([!\\[\\].:\\w ]+)?\\}'
+        name: 'constant.other.placeholder.format.python3'
+      }
+    ]
+
+  docstrings:
+    patterns: [
+      {
+        begin: '^\\s*(?=([uU]|[rR][bB]?|[bB][rR]?)?""")'
+        end: '(?<=""")'
+        name: 'comment.block.python3'
+        patterns: [
+          {
+            include: '#string_quoted_double'
+          }
+        ]
+      }
+      {
+        begin: '^\\s*(?=([uU]|[rR][bB]?|[bB][rR]?)?\'\'\')'
+        end: '(?<=\'\'\')'
+        name: 'comment.block.python3'
+        patterns: [
+          {
+            include: '#string_quoted_single'
+          }
+        ]
+      }
+    ]
+
+  line_comments:
+    begin: '(^[ \\t]+)?(?=#)'
+    beginCaptures:
+      '1':
+        name: 'punctuation.whitespace.comment.leading.python3'
+    end: '(?!\\G)'
+    patterns: [
+      {
+        begin: '#'
+        beginCaptures:
+          '0':
+            name: 'punctuation.definition.comment.python3'
+        end: '\\n'
+        name: 'comment.line.number-sign.python3'
+      }
+    ]
+
+  dotted_name:
+    begin: '(?=[A-Za-z_][A-Za-z0-9_]*(?:\\.[A-Za-z_][A-Za-z0-9_]*)*)'
+    end: '(?![A-Za-z0-9_\\.])'
+    patterns: [
+      {
+        begin: '(\\.)(?=[A-Za-z_][A-Za-z0-9_]*)'
+        end: '(?![A-Za-z0-9_])'
+        patterns: [
+          {
+            include: '#magic_function_names'
+          }
+          {
+            include: '#magic_variable_names'
+          }
+          {
+            include: '#illegal_names'
+          }
+          {
+            include: '#generic_names'
+          }
+        ]
+      }
+      {
+        begin: '(?<!\\.)(?=[A-Za-z_][A-Za-z0-9_]*)'
+        end: '(?![A-Za-z0-9_])'
+        patterns: [
+          {
+            include: '#builtin_functions'
+          }
+          {
+            include: '#builtin_types'
+          }
+          {
+            include: '#builtin_exceptions'
+          }
+          {
+            include: '#illegal_names'
+          }
+          {
+            include: '#magic_function_names'
+          }
+          {
+            include: '#magic_variable_names'
+          }
+          {
+            include: '#language_variables'
+          }
+          {
+            include: '#generic_names'
+          }
+        ]
+      }
+    ]
+
+  entity_name_class:
+    patterns: [
+      {
+        include: '#illegal_names'
+      }
+      {
+        include: '#generic_names'
+      }
+    ]
+
+  entity_name_function:
+    patterns: [
+      {
+        include: '#magic_function_names'
+      }
+      {
+        include: '#illegal_names'
+      }
+      {
+        include: '#generic_names'
+      }
+    ]
+
+  escaped_char:
+    match: '''
+    (?x)(\\\\x[0-9A-F]{2})|(\\\\[0-7]{3})
+    |(\\\\\\n)|(\\\\\\\\)|(\\\\\\")|(\\\\\')|(\\\\a)|(\\\\b)|(\\\\f)|(\\\\n)
+    |(\\\\r)|(\\\\t)|(\\\\v)
+    '''
+    captures:
+      '1':
+        name: 'constant.character.escape.hex.python3'
+      '2':
+        name: 'constant.character.escape.octal.python3'
+      '3':
+        name: 'constant.character.escape.newline.python3'
+      '4':
+        name: 'constant.character.escape.backlash.python3'
+      '5':
+        name: 'constant.character.escape.double-quote.python3'
+      '6':
+        name: 'constant.character.escape.single-quote.python3'
+      '7':
+        name: 'constant.character.escape.bell.python3'
+      '8':
+        name: 'constant.character.escape.backspace.python3'
+      '9':
+        name: 'constant.character.escape.formfeed.python3'
+      '10':
+        name: 'constant.character.escape.linefeed.python3'
+      '11':
+        name: 'constant.character.escape.return.python3'
+      '12':
+        name: 'constant.character.escape.tab.python3'
+      '13':
+        name: 'constant.character.escape.vertical-tab.python3'
+
+  escaped_unicode_char:
+    match: '(\\\\U[0-9A-Fa-f]{8})|(\\\\u[0-9A-Fa-f]{4})|(\\\\N\\{[a-zA-Z ]+\\})'
+    captures:
+      '1':
+        name: 'constant.character.escape.unicode.16-bit-hex.python3'
+      '2':
+        name: 'constant.character.escape.unicode.32-bit-hex.python3'
+      '3':
+        name: 'constant.character.escape.unicode.name.python3'
+
+  function_name:
+    patterns: [
+      {
+        include: '#magic_function_names'
+      }
+      {
+        include: '#magic_variable_names'
+      }
+      {
+        include: '#builtin_exceptions'
+      }
+      {
+        include: '#builtin_functions'
+      }
+      {
+        include: '#builtin_types'
+      }
+      {
+        include: '#generic_names'
+      }
+    ]
+
+  function_definition:
+    patterns: [
+      {
+        begin: '^\\s*(?:(async)\\s+)?(def)\\s+(?=[A-Za-z_][A-Za-z0-9_]*\\s*\\()'
+        beginCaptures:
+          '1':
+            name: 'storage.modifier.coroutine.python3'
+          '2':
+            name: 'storage.type.function.python3'
+        end: '(\\))\\s*(?:(\\:)|(.*$\\n?))'
+        endCaptures:
+          '1':
+            name: 'punctuation.definition.parameters.end.python3'
+          '2':
+            name: 'punctuation.section.function.begin.python3'
+          '3':
+            name: 'invalid.illegal.missing-section-begin.python3'
+        name: 'meta.function.python3'
+        patterns: [
+          {
+            begin: '(?=[A-Za-z_][A-Za-z0-9_]*)'
+            contentName: 'entity.name.function.python3'
+            end: '(?![A-Za-z0-9_])'
+            patterns: [
+              {
+                include: '#entity_name_function'
+              }
+            ]
+          }
+          {
+            begin: '(\\()'
+            beginCaptures:
+              '1':
+                name: 'punctuation.definition.parameters.begin.python3'
+            contentName: 'meta.function.parameters.python3'
+            end: '(?=\\)\\s*\\:)'
+            patterns: [
+              {
+                include: '#line_comments'
+              }
+              {
+                include: '#keyword_arguments'
+              }
+              {
+                captures:
+                  '1':
+                    name: 'variable.parameter.function.python3'
+                  '2':
+                    name: 'punctuation.separator.parameters.python3'
+                match: '\\b([a-zA-Z_][a-zA-Z_0-9]*)\\s*(?:(,)|(?=[\\n\\)]))'
+              }
+            ]
+          }
+        ]
+      }
+      {
+        begin: '^\\s*(?:(async)\\s+)?(def)\\s+(?=[A-Za-z_][A-Za-z0-9_]*)'
+        beginCaptures:
+          '1':
+            name: 'storage.type.function.python3'
+        end: '(\\()|\\s*($\\n?|#.*$\\n?)'
+        endCaptures:
+          '1':
+            name: 'punctuation.definition.parameters.begin.python3'
+          '2':
+            name: 'invalid.illegal.missing-parameters.python3'
+        name: 'meta.function.python3'
+        patterns: [
+          {
+            begin: '(?=[A-Za-z_][A-Za-z0-9_]*)'
+            contentName: 'entity.name.function.python3'
+            end: '(?![A-Za-z0-9_])'
+            patterns: [
+              {
+                include: '#entity_name_function'
+              }
+            ]
+          }
+        ]
+      }
+      {
+        begin: '(lambda)(?=\\s+)'
+        beginCaptures:
+          '1':
+            name: 'storage.type.function.inline.python3'
+        end: '(\\:)'
+        endCaptures:
+          '1':
+            name: 'punctuation.definition.parameters.end.python3'
+          '2':
+            name: 'punctuation.section.function.begin.python3'
+          '3':
+            name: 'invalid.illegal.missing-section-begin.python3'
+        name: 'meta.function.inline.python3'
+        patterns: [
+          {
+            begin: '\\s+'
+            contentName: 'meta.function.inline.parameters.python3'
+            end: '(?=\\:)'
+            patterns: [
+              {
+                include: '#keyword_arguments'
+              }
+              {
+                captures:
+                  '1':
+                    name: 'variable.parameter.function.python3'
+                  '2':
+                    name: 'punctuation.separator.parameters.python3'
+                match: '\\b([a-zA-Z_][a-zA-Z_0-9]*)\\s*(?:(,)|(?=[\\n\\)\\:]))'
+              }
+            ]
+          }
+        ]
+      }
+      {
+        comment: 'a decorator may be a function call which returns a decorator.'
+        begin: '^\\s*(?=@\\s*[A-Za-z_][A-Za-z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z_0-9]*)*\\s*\\()'
+        end: '(\\))'
+        endCaptures:
+          '1':
+            name: 'punctuation.definition.arguments.end.python3'
+        name: 'meta.function.decorator.python3'
+        patterns: [
+          {
+            begin: '(?=(@)\\s*[A-Za-z_][A-Za-z0-9_]*(?:\\.[A-Za-z_][A-Za-z0-9_]*)*\\s*\\()'
+            beginCaptures:
+              '1':
+                name: 'punctuation.definition.decorator.python3'
+            contentName: 'entity.name.function.decorator.python3'
+            end: '(?=\\s*\\()'
+            patterns: [
+              {
+                include: '#dotted_name'
+              }
+            ]
+          }
+          {
+            begin: '(\\()'
+            beginCaptures:
+              '1':
+                name: 'punctuation.definition.arguments.begin.python3'
+            contentName: 'meta.function.decorator.arguments.python3'
+            end: '(?=\\))'
+            patterns: [
+              {
+                include: '#keyword_arguments'
+              }
+              {
+                include: '$self'
+              }
+            ]
+          }
+        ]
+      }
+      {
+        begin: '^\\s*(?=@\\s*[A-Za-z_][A-Za-z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z_0-9]*)*)'
+        contentName: 'entity.name.function.decorator.python3'
+        end: '(?=\\s|$\\n?|#)'
+        name: 'meta.function.decorator.python3'
+        patterns: [
+          {
+            begin: '(?=(@)\\s*[A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)*)'
+            beginCaptures:
+              '1':
+                name: 'punctuation.definition.decorator.python3'
+            end: '(?=\\s|$\\n?|#)'
+            patterns: [
+              {
+                include: '#dotted_name'
+              }
+            ]
+          }
+        ]
+      }
+    ]
+
+  generic_names:
+    match: '[A-Za-z_][A-Za-z0-9_]*'
+
+  illegal_names:
+    match: '''
+    (?x)\\b(
+    False|None|True|and|as|assert|break|class|continue|def|del|elif|else|except
+    |finally|for|from|global|if|import|in|is|lambda|nonlocal|not|or|pass|raise
+    |return|try|while|with|yield
+    )\\b
+    '''
+    name: 'invalid.illegal.name.python3'
+
+  keyword_arguments:
+    begin: '\\b([a-zA-Z_][a-zA-Z_0-9]*)\\s*(=)(?!=)'
+    beginCaptures:
+      '1':
+        name: 'variable.parameter.function.python3'
+      '2':
+        name: 'keyword.operator.assignment.python3'
+    end: '\\s*(?:(,)|(?=$\\n?|[\\)\\:]))'
+    endCaptures:
+      '1':
+        name: 'punctuation.separator.parameters.python3'
+    patterns: [
+      {
+        include: '$self'
+      }
+    ]
+
+  language_variables:
+    match: '\\b(self|cls)\\b'
+    name: 'variable.language.python3'
+
+  line_continuation:
+    match: '(\\\\)(.*)$\\n?'
+    captures:
+      '1':
+        name: 'punctuation.separator.continuation.line.python3'
+      '2':
+        name: 'invalid.illegal.unexpected-text.python3'
+
+  magic_function_names:
+    comment: 'these methods have magic interpretation by python and are generally called indirectly through syntactic constructs'
+    match: '''
+    (?x)\\b__(
+    new|init|del|repr|str|bytes|format|hash|bool
+    |lt|le|eq|ne|gt|ge
+    |getattr|getattribute|setattr|delattr|dir
+    |get|set|delete
+    |slots
+    |instancecheck|subclasscheck
+    |call
+    |len|len_hint|getitem|missing|setitem|delitem|iter|reversed|contains
+    |add|sub|mul|matmul|truediv|floordiv|mod|divmod|pow|lshift|rshift|and|xor
+    |or|radd|rsub|rmul|rmatmul|rtruediv|rfloordiv|rmod|rdivmod|rpow|rlshift
+    |rrshift|rand|rxor|ror|iadd|isub|imul|imatmul|itruediv|ifloordiv|imod
+    |idivmod|ipow|ilshift|irshift|iand|ixor|ior|neg|pos|abs|invert|complex
+    |int|float|round|index
+    |enter|exit
+    |await
+    |aiter|anext
+    |aenter|aexit
+    )__\\b
+    '''
+    name: 'support.function.magic.python3'
+
+  magic_variable_names:
+    comment: 'magic variables which a class/module may have.'
+    match: '''
+    (?x)\\b__(
+    all|annotations|bases|class|closure|code|debug|dict|doc|file|func|globals|kwdefaults|members|methods|module|name|qualname|self|slots|weakref
+    )__\\b
+    '''
+    name: 'support.variable.magic.python3'
+
+  regular_expressions:
+    comment: 'Changed disabled to 1 to turn off syntax highlighting in “r” strings.'
+    disabled: 0
+    patterns: [
+      {
+        include: 'source.regexp.python3'
+      }
+    ]
+
+  string_quoted_double:
+    patterns: [
+      {
+        comment: 'double quoted block raw bytes string'
+        begin: '([bB][rR]|[rR][bB])(""")'
+        beginCaptures:
+          '1':
+            name: 'storage.type.string.python3'
+          '2':
+            name: 'punctuation.definition.string.begin.python3'
+        end: '((?<=""")(")""|""")'
+        endCaptures:
+          '1':
+            name: 'punctuation.definition.string.end.python3'
+          '2':
+            name: 'meta.empty-string.double.python3'
+        name: 'string.quoted.double.block.bytes-raw.python3'
+        patterns: [
+          {
+            include: '#regular_expressions'
+          }
+        ]
+      }
+      {
+        comment: 'double quoted block bytes string'
+        begin: '([bB])(""")'
+        beginCaptures:
+          '1':
+            name: 'storage.type.string.python3'
+          '2':
+            name: 'punctuation.definition.string.begin.python3'
+        end: '((?<=""")(")""|""")'
+        endCaptures:
+          '1':
+            name: 'punctuation.definition.string.end.python3'
+          '2':
+            name: 'meta.empty-string.double.python3'
+        name: 'string.quoted.double.block.bytes.python3'
+        patterns: [
+          {
+            include: '#constant_placeholder_printf'
+          }
+          {
+            include: '#escaped_char'
+          }
+        ]
+      }
+      {
+        comment: 'double quoted block raw unicode string'
+        begin: '([rR])(""")'
+        beginCaptures:
+          '1':
+            name: 'storage.type.string.python3'
+          '2':
+            name: 'punctuation.definition.string.begin.python3'
+        end: '((?<=""")(")""|""")'
+        endCaptures:
+          '1':
+            name: 'punctuation.definition.string.end.python3'
+          '2':
+            name: 'meta.empty-string.double.python3'
+        name: 'string.quoted.double.block.unicode-raw.python3'
+        patterns: [
+          {
+            include: '#regular_expressions'
+          }
+        ]
+      }
+      {
+        comment: 'double quoted block unicode string'
+        begin: '([uU]?)(""")'
+        beginCaptures:
+          '1':
+            name: 'storage.type.string.python3'
+          '2':
+            name: 'punctuation.definition.string.begin.python3'
+        end: '((?<=""")(")""|""")'
+        endCaptures:
+          '1':
+            name: 'punctuation.definition.string.end.python3'
+          '2':
+            name: 'meta.empty-string.double.python3'
+        name: 'string.quoted.double.block.unicode.python3'
+        patterns: [
+          {
+            include: '#constant_placeholder_printf'
+          }
+          {
+            include: '#constant_placeholder_format'
+          }
+          {
+            include: '#escaped_unicode_char'
+          }
+          {
+            include: '#escaped_char'
+          }
+        ]
+      }
+      {
+        comment: 'double quoted bytes-raw string'
+        begin: '([bB][rR]|[rR][bB])(")'
+        beginCaptures:
+          '1':
+            name: 'storage.type.string.python3'
+          '2':
+            name: 'punctuation.definition.string.begin.python3'
+        end: '((?<=")(")|")|(\\n)'
+        endCaptures:
+          '1':
+            name: 'punctuation.definition.string.end.python3'
+          '2':
+            name: 'meta.empty-string.double.python3'
+          '3':
+            name: 'invalid.illegal.unclosed-string.python3'
+        name: 'string.quoted.double.single-line.bytes-raw.python3'
+        patterns: [
+          {
+            match: '(\\\\\\n)|(\\\\")'
+            captures:
+              '1':
+                name: 'constant.character.escape.newline.python3'
+              '2':
+                name: 'constant.character.escape.double-quote.python3'
+          }
+          {
+            include: '#regular_expressions'
+          }
+        ]
+      }
+      {
+        comment: 'double quoted bytes string'
+        begin: '([bB])(")'
+        beginCaptures:
+          '1':
+            name: 'storage.type.string.python3'
+          '2':
+            name: 'punctuation.definition.string.begin.python3'
+        end: '((?<=")(")|")|(\\n)'
+        endCaptures:
+          '1':
+            name: 'punctuation.definition.string.end.python3'
+          '2':
+            name: 'meta.empty-string.double.python3'
+          '3':
+            name: 'invalid.illegal.unclosed-string.python3'
+        name: 'string.quoted.double.single-line.bytes.python3'
+        patterns: [
+          {
+            include: '#constant_placeholder_printf'
+          }
+          {
+            include: '#escaped_char'
+          }
+        ]
+      }
+      {
+        comment: 'double quoted unicode-raw string'
+        begin: '([rR])(")'
+        beginCaptures:
+          '1':
+            name: 'storage.type.string.python3'
+          '2':
+            name: 'punctuation.definition.string.begin.python3'
+        end: '((?<=")(")|")|(\\n)'
+        endCaptures:
+          '1':
+            name: 'punctuation.definition.string.end.python3'
+          '2':
+            name: 'meta.empty-string.double.python3'
+          '3':
+            name: 'invalid.illegal.unclosed-string.python3'
+        name: 'string.quoted.double.single-line.unicode-raw.python3'
+        patterns: [
+          {
+            match: '(\\\\\\n)|(\\\\")'
+            captures:
+              '1':
+                name: 'constant.character.escape.newline.python3'
+              '2':
+                name: 'constant.character.escape.double-quote.python3'
+          }
+          {
+            include: '#regular_expressions'
+          }
+        ]
+      }
+      {
+        comment: 'double quoted unicode string'
+        begin: '([uU]?)(")'
+        beginCaptures:
+          '1':
+            name: 'storage.type.string.python3'
+          '2':
+            name: 'punctuation.definition.string.begin.python3'
+        end: '((?<=")(")|")|(\\n)'
+        endCaptures:
+          '1':
+            name: 'punctuation.definition.string.end.python3'
+          '2':
+            name: 'meta.empty-string.double.python3'
+          '3':
+            name: 'invalid.illegal.unclosed-string.python3'
+        name: 'string.quoted.double.single-line.unicode.python3'
+        patterns: [
+          {
+            include: '#constant_placeholder_printf'
+          }
+          {
+            include: '#constant_placeholder_format'
+          }
+          {
+            include: '#escaped_unicode_char'
+          }
+          {
+            include: '#escaped_char'
+          }
+        ]
+      }
+    ]
+
+  string_quoted_single:
+    patterns: [
+      {
+        comment: 'single quoted block raw bytes string'
+        begin: '([bB][rR]|[rR][bB])(\'\'\')'
+        beginCaptures:
+          '1':
+            name: 'storage.type.string.python3'
+          '2':
+            name: 'punctuation.definition.string.begin.python3'
+        end: '((?<=\'\'\')(\')\'\'|\'\'\')'
+        endCaptures:
+          '1':
+            name: 'punctuation.definition.string.end.python3'
+          '2':
+            name: 'meta.empty-string.single.python3'
+        name: 'string.quoted.single.block.bytes-raw.python3'
+        patterns: [
+          {
+            include: '#regular_expressions'
+          }
+        ]
+      }
+      {
+        comment: 'single quoted block bytes string'
+        begin: '([bB])(\'\'\')'
+        beginCaptures:
+          '1':
+            name: 'storage.type.string.python3'
+          '2':
+            name: 'punctuation.definition.string.begin.python3'
+        end: '((?<=\'\'\')(\')\'\'|\'\'\')'
+        endCaptures:
+          '1':
+            name: 'punctuation.definition.string.end.python3'
+          '2':
+            name: 'meta.empty-string.single.python3'
+        name: 'string.quoted.single.block.bytes.python3'
+        patterns: [
+          {
+            include: '#constant_placeholder_printf'
+          }
+          {
+            include: '#escaped_char'
+          }
+        ]
+      }
+      {
+        comment: 'single quoted block raw unicode string'
+        begin: '([rR])(\'\'\')'
+        beginCaptures:
+          '1':
+            name: 'storage.type.string.python3'
+          '2':
+            name: 'punctuation.definition.string.begin.python3'
+        end: '((?<=\'\'\')(\')\'\'|\'\'\')'
+        endCaptures:
+          '1':
+            name: 'punctuation.definition.string.end.python3'
+          '2':
+            name: 'meta.empty-string.single.python3'
+        name: 'string.quoted.single.block.unicode-raw.python3'
+        patterns: [
+          {
+            include: '#regular_expressions'
+          }
+        ]
+      }
+      {
+        comment: 'single quoted block unicode string'
+        begin: '([uU]?)(\'\'\')'
+        beginCaptures:
+          '1':
+            name: 'storage.type.string.python3'
+          '2':
+            name: 'punctuation.definition.string.begin.python3'
+        end: '((?<=\'\'\')(\')\'\'|\'\'\')'
+        endCaptures:
+          '1':
+            name: 'punctuation.definition.string.end.python3'
+          '2':
+            name: 'meta.empty-string.single.python3'
+        name: 'string.quoted.single.block.unicode.python3'
+        patterns: [
+          {
+            include: '#constant_placeholder_printf'
+          }
+          {
+            include: '#constant_placeholder_format'
+          }
+          {
+            include: '#escaped_unicode_char'
+          }
+          {
+            include: '#escaped_char'
+          }
+        ]
+      }
+      {
+        comment: 'single quoted bytes-raw string'
+        begin: '([bB][rR]|[rR][bB])(\')'
+        beginCaptures:
+          '1':
+            name: 'storage.type.string.python3'
+          '2':
+            name: 'punctuation.definition.string.begin.python3'
+        end: '((?<=\')(\')|\')|(\\n)'
+        endCaptures:
+          '1':
+            name: 'punctuation.definition.string.end.python3'
+          '2':
+            name: 'meta.empty-string.single.python3'
+          '3':
+            name: 'invalid.illegal.unclosed-string.python3'
+        name: 'string.quoted.single.single-line.bytes-raw.python3'
+        patterns: [
+          {
+            match: '(\\\\\\n)|(\\\\\')'
+            captures:
+              '1':
+                name: 'constant.character.escape.newline.python3'
+              '2':
+                name: 'constant.character.escape.double-quote.python3'
+          }
+          {
+            include: '#regular_expressions'
+          }
+        ]
+      }
+      {
+        comment: 'single quoted bytes string'
+        begin: '([bB])(\')'
+        beginCaptures:
+          '1':
+            name: 'storage.type.string.python3'
+          '2':
+            name: 'punctuation.definition.string.begin.python3'
+        end: '((?<=\')(\')|\')|(\\n)'
+        endCaptures:
+          '1':
+            name: 'punctuation.definition.string.end.python3'
+          '2':
+            name: 'meta.empty-string.single.python3'
+          '3':
+            name: 'invalid.illegal.unclosed-string.python3'
+        name: 'string.quoted.single.single-line.bytes.python3'
+        patterns: [
+          {
+            include: '#constant_placeholder_printf'
+          }
+          {
+            include: '#escaped_char'
+          }
+        ]
+      }
+      {
+        comment: 'single quoted unicode-raw string'
+        begin: '([rR])(\')'
+        beginCaptures:
+          '1':
+            name: 'storage.type.string.python3'
+          '2':
+            name: 'punctuation.definition.string.begin.python3'
+        end: '((?<=\')(\')|\')|(\\n)'
+        endCaptures:
+          '1':
+            name: 'punctuation.definition.string.end.python3'
+          '2':
+            name: 'meta.empty-string.single.python3'
+          '3':
+            name: 'invalid.illegal.unclosed-string.python3'
+        name: 'string.quoted.single.single-line.unicode-raw.python3'
+        patterns: [
+          {
+            match: '(\\\\\\n)|(\\\\\')'
+            captures:
+              '1':
+                name: 'constant.character.escape.newline.python3'
+              '2':
+                name: 'constant.character.escape.double-quote.python3'
+          }
+          {
+            include: '#regular_expressions'
+          }
+        ]
+      }
+      {
+        comment: 'single quoted unicode string'
+        begin: '([uU]?)(\')'
+        beginCaptures:
+          '1':
+            name: 'storage.type.string.python3'
+          '2':
+            name: 'punctuation.definition.string.begin.python3'
+        end: '((?<=\')(\')|\')|(\\n)'
+        endCaptures:
+          '1':
+            name: 'punctuation.definition.string.end.python3'
+          '2':
+            name: 'meta.empty-string.single.python3'
+          '3':
+            name: 'invalid.illegal.unclosed-string.python3'
+        name: 'string.quoted.single.single-line.unicode.python3'
+        patterns: [
+          {
+            include: '#constant_placeholder_printf'
+          }
+          {
+            include: '#constant_placeholder_format'
+          }
+          {
+            include: '#escaped_unicode_char'
+          }
+          {
+            include: '#escaped_char'
+          }
+        ]
+      }
+    ]
+
+  strings:
+    patterns: [
+      {
+        include: '#string_quoted_double'
+      }
+      {
+        include: '#string_quoted_single'
+      }
+    ]
+
+patterns: [
+  {
+    include: '#line_comments'
+  }
+  {
+    include: '#function_definition'
+  }
+  {
+    match: '\\b(?i:(0x\\h*)L)'
+    name: 'constant.numeric.integer.long.hexadecimal.python3'
+  }
+  {
+    match: '\\b(?i:(0x\\h*))'
+    name: 'constant.numeric.integer.hexadecimal.python3'
+  }
+  {
+    match: '\\b(?i:(0o?[0-7]+)L)'
+    name: 'constant.numeric.integer.long.octal.python3'
+  }
+  {
+    match: '\\b(?i:(0o?[0-7]+))'
+    name: 'constant.numeric.integer.octal.python3'
+  }
+  {
+    match: '\\b(?i:(0b[01]+)L)',
+    name: 'constant.numeric.integer.long.binary.python3'
+  }
+  {
+    match: '\\b(?i:(0b[01]+))',
+    name: 'constant.numeric.integer.binary.python3'
+  }
+  {
+    match: '\\b(?i:(((\\d+(\\.(?=[^a-zA-Z_])\\d*)?|(?<=[^0-9a-zA-Z_])\\.\\d+)(e[\\-\\+]?\\d+)?))J)'
+    name: 'constant.numeric.complex.python3'
+  }
+  {
+    match: '\\b(?i:(\\d+\\.\\d*(e[\\-\\+]?\\d+)?))(?=[^a-zA-Z_])'
+    name: 'constant.numeric.float.python3'
+  }
+  {
+    match: '(?<=[^0-9a-zA-Z_])(?i:(\\.\\d+(e[\\-\\+]?\\d+)?))'
+    name: 'constant.numeric.float.python3'
+  }
+  {
+    match: '\\b(?i:(\\d+e[\\-\\+]?\\d+))'
+    name: 'constant.numeric.float.python3'
+  }
+  {
+    match: '\\b(?i:([1-9]+[0-9]*|0)L)'
+    name: 'constant.numeric.integer.long.decimal.python3'
+  }
+  {
+    match: '\\b([1-9]+[0-9]*|0)'
+    name: 'constant.numeric.integer.decimal.python3'
+  }
+  {
+    match: '\\b(global)\\b'
+    name: 'storage.modifier.global.python3'
+  }
+  {
+    match: '\\b(nonlocal)\\b'
+    name: 'storage.modifier.nonlocal.python3'
+  }
+  {
+    match: '\\b(async)\\b'
+    name: 'storage.modifier.coroutine.python3'
+  }
+  {
+    captures:
+      '1':
+        name: 'keyword.control.import.python3'
+      '2':
+        name: 'keyword.control.import.from.python3'
+    match: '\\b(?:(import)|(from))\\b'
+  }
+  {
+    comment: 'keywords that delimit flow conditionals'
+    name: 'keyword.control.conditional.python3'
+    match: '\\b(if|elif|else)\\b'
+  }
+  {
+    comment: 'keywords that delimit an exception'
+    name: 'keyword.control.exception.python3'
+    match: '\\b(except|finally|try|raise)\\b'
+  }
+  {
+    comment: 'keywords that delimit loops'
+    match: '\\b(for|while)\\b'
+    name: 'keyword.control.repeat.python3'
+  }
+  {
+    comment: 'keywords that alter flow from within a block'
+    name: 'keyword.control.statement.python3'
+    match: '\\b(with|break|continue|pass|return|yield|await)\\b'
+  }
+  {
+    comment: 'keyword operators that evaluate to True or False'
+    match: '\\b(and|in|is|not|or)\\b'
+    name: 'keyword.operator.logical.python3'
+  }
+  {
+    comment: 'keywords that haven\'t fit into other groups (yet).'
+    match: '\\b(as|assert|del)\\b'
+    captures:
+      '1':
+        name: 'keyword.other.python3'
+  }
+  {
+    match: '<\\=|>\\=|\\=\\=|<|>|\\!\\='
+    name: 'keyword.operator.comparison.python3'
+  }
+  {
+    match: '\\+\\=|-\\=|\\*\\=|/\\=|//\\=|%\\=|@=|&\\=|\\|\\=|\\^\\=|>>\\=|<<\\=|\\*\\*\\='
+    name: 'keyword.operator.assignment.augmented.python3'
+  }
+  {
+    match: '\\+|\\-|\\*|\\*\\*|/|//|%|@|<<|>>|&|\\||\\^|~'
+    name: 'keyword.operator.arithmetic.python3'
+  }
+  {
+    match: '\\='
+    name: 'keyword.operator.assignment.python3'
+  }
+  {
+    begin: '^\\s*(class)\\s+(?=[a-zA-Z_][a-zA-Z_0-9]*\\s*\\:)'
+    beginCaptures:
+      '1':
+        name: 'storage.type.class.python3'
+    contentName: 'entity.name.type.class.python3'
+    end: '\\s*(:)'
+    endCaptures:
+      '1':
+        name: 'punctuation.section.class.begin.python3'
+    name: 'meta.class.old-style.python3'
+    patterns: [
+      {
+        include: '#entity_name_class'
+      }
+    ]
+  }
+  {
+    begin: '^\\s*(class)\\s+(?=[a-zA-Z_][a-zA-Z_0-9]*\\s*\\()'
+    beginCaptures:
+      '1':
+        name: 'storage.type.class.python3'
+    end: '(\\))\\s*(?:(\\:)|(.*$\\n?))'
+    endCaptures:
+      '1':
+        name: 'punctuation.definition.inheritance.end.python3'
+      '2':
+        name: 'punctuation.section.class.begin.python3'
+      '3':
+        name: 'invalid.illegal.missing-section-begin.python3'
+    name: 'meta.class.python3'
+    patterns: [
+      {
+        begin: '(?=[A-Za-z_][A-Za-z0-9_]*)'
+        contentName: 'entity.name.type.class.python3'
+        end: '(?![A-Za-z0-9_])'
+        patterns: [
+          {
+            include: '#entity_name_class'
+          }
+        ]
+      }
+      {
+        begin: '(\\()'
+        beginCaptures:
+          '1':
+            name: 'punctuation.definition.inheritance.begin.python3'
+        contentName: 'meta.class.inheritance.python3'
+        end: '(?=\\)|:)'
+        patterns: [
+          {
+            begin: '(?<=\\(|,)\\s*'
+            contentName: 'entity.other.inherited-class.python3'
+            end: '\\s*(?:(,)|(?=\\)))'
+            endCaptures:
+              '1':
+                name: 'punctuation.separator.inheritance.python3'
+            patterns: [
+              {
+                include: '$self'
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+  {
+    begin: '^\\s*(class)\\s+(?=[a-zA-Z_][a-zA-Z_0-9])'
+    beginCaptures:
+      '1':
+        name: 'storage.type.class.python3'
+    end: '(\\()|(\\s*$\\n?|#.*$\\n?)'
+    endCaptures:
+      '1':
+        name: 'punctuation.definition.inheritance.begin.python3'
+      '2':
+        name: 'invalid.illegal.missing-inheritance.python3'
+    name: 'meta.class.python3'
+    patterns: [
+      {
+        begin: '(?=[A-Za-z_][A-Za-z0-9_]*)'
+        contentName: 'entity.name.type.class.python3'
+        end: '(?![A-Za-z0-9_])'
+        patterns: [
+          {
+            include: '#entity_name_function'
+          }
+        ]
+      }
+    ]
+  }
+  {
+    begin: '(?<=\\)|\\])\\s*(\\()'
+    beginCaptures:
+      '1':
+        name: 'punctuation.definition.arguments.begin.python3'
+    contentName: 'meta.function-call.arguments.python3'
+    end: '(\\))'
+    endCaptures:
+      '1':
+        name: 'punctuation.definition.arguments.end.python3'
+    name: 'meta.function-call.python3'
+    patterns: [
+      {
+        include: '#keyword_arguments'
+      }
+      {
+        include: '$self'
+      }
+    ]
+  }
+  {
+    begin: '(?=[A-Za-z_][A-Za-z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z_0-9]*)*\\s*\\()'
+    end: '(\\))'
+    endCaptures:
+      '1':
+        name: 'punctuation.definition.arguments.end.python3'
+    name: 'meta.function-call.python3'
+    patterns: [
+      {
+        begin: '(?=[A-Za-z_][A-Za-z0-9_]*(?:\\.[A-Za-z_][A-Za-z0-9_]*)*\\s*\\()'
+        end: '(?=\\s*\\()'
+        patterns: [
+          {
+            include: '#dotted_name'
+          }
+        ]
+      }
+      {
+        begin: '(\\()'
+        beginCaptures:
+          '1':
+            name: 'punctuation.definition.arguments.begin.python3'
+        contentName: 'meta.function-call.arguments.python3'
+        end: '(?=\\))'
+        patterns: [
+          {
+            include: '#keyword_arguments'
+          }
+          {
+            include: '$self'
+          }
+        ]
+      }
+    ]
+  }
+  {
+    begin: '(?=[A-Za-z_][A-Za-z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z_0-9]*)*\\s*\\[)'
+    end: '(\\])'
+    endCaptures:
+      '1':
+        name: 'punctuation.definition.arguments.end.python3'
+    name: 'meta.item-access.python3'
+    patterns: [
+      {
+        begin: '(?=[A-Za-z_][A-Za-z0-9_]*(?:\\.[A-Za-z_][A-Za-z0-9_]*)*\\s*\\[)'
+        end: '(?=\\s*\\[)'
+        patterns: [
+          {
+            include: '#dotted_name'
+          }
+        ]
+      }
+      {
+        begin: '(\\[)'
+        beginCaptures:
+          '1':
+            name: 'punctuation.definition.arguments.begin.python3'
+        contentName: 'meta.item-access.arguments.python3'
+        end: '(?=\\])'
+        patterns: [
+          {
+            include: '$self'
+          }
+        ]
+      }
+    ]
+  }
+  {
+    begin: '(?<=\\)|\\])\\s+(\\[)'
+    beginCaptures:
+      '1':
+        name: 'punctuation.definition.arguments.begin.python3'
+    contentName: 'meta.item-access.arguments.python3'
+    end: '(\\])'
+    endCaptures:
+      '1':
+        name: 'punctuation.definition.arguments.end.python3'
+    name: 'meta.item-access.python3'
+    patterns: [
+      {
+        include: '$self'
+      }
+    ]
+  }
+  {
+    captures:
+      '1':
+        name: 'storage.type.function.python3'
+    match: '\\b(def|lambda)\\b'
+  }
+  {
+    captures:
+      '1':
+        name: 'storage.type.class.python3'
+    match: '\\b(class)\\b'
+  }
+  {
+    include: '#line_continuation'
+  }
+  {
+    match: '\\b(None|True|False|Ellipsis|NotImplemented)\\b'
+    name: 'constant.language.python3'
+  }
+  {
+    include: '#string_quoted_single'
+  }
+  {
+    include: '#string_quoted_double'
+  }
+  {
+    include: '#dotted_name'
+  }
+  {
+    include: '#language_variables'
+  }
+  # {
+  #   begin: '(\\()'
+  #   end: '(\\))'
+  #   patterns: [
+  #     {
+  #       include: '$self'
+  #     }
+  #   ]
+  # }
+  # {
+  #   captures:
+  #     '1':
+  #       name: 'punctuation.definition.list.begin.python3'
+  #     '2':
+  #       name: 'meta.empty-list.python3'
+  #     '3':
+  #       name: 'punctuation.definition.list.end.python3'
+  #   match: '(\\[)(\\s*(\\]))\\b'
+  # }
+  # {
+  #   begin: '(\\[)'
+  #   beginCaptures:
+  #     '1':
+  #       name: 'punctuation.definition.list.begin.python3'
+  #   end: '(\\])'
+  #   endCaptures:
+  #     '1':
+  #       name: 'punctuation.definition.list.end.python3'
+  #   name: 'meta.structure.list.python3'
+  #   patterns: [
+  #     {
+  #       begin: '(?<=\\[|\\,)\\s*(?![\\],])'
+  #       contentName: 'meta.structure.list.item.python3'
+  #       end: '\\s*(?:(,)|(?=\\]))'
+  #       endCaptures:
+  #         '1':
+  #           name: 'punctuation.separator.list.python3'
+  #       patterns: [
+  #         {
+  #           include: '$self'
+  #         }
+  #       ]
+  #     }
+  #   ]
+  # }
+  # {
+  #   captures:
+  #     '1':
+  #       name: 'punctuation.definition.tuple.begin.python3'
+  #     '2':
+  #       name: 'meta.empty-tuple.python3'
+  #     '3':
+  #       name: 'punctuation.definition.tuple.end.python3'
+  #   match: '(\\()(\\s*(\\)))'
+  #   name: 'meta.structure.tuple.python3'
+  # }
+  # {
+  #   captures:
+  #     '1':
+  #       name: 'punctuation.definition.dictionary.begin.python3'
+  #     '2':
+  #       name: 'meta.empty-dictionary.python3'
+  #     '3':
+  #       name: 'punctuation.definition.dictionary.end.python3'
+  #   match: '(\\{)(\\s*(\\}))'
+  #   name: 'meta.structure.dictionary.python3'
+  # }
+  # {
+  #   begin: '(\\{)'
+  #   beginCaptures:
+  #     '1':
+  #       name: 'punctuation.definition.dictionary.begin.python3'
+  #   end: '(\\})'
+  #   endCaptures:
+  #     '1':
+  #       name: 'punctuation.definition.dictionary.end.python3'
+  #   name: 'meta.structure.dictionary.python3'
+  #   patterns: [
+  #     {
+  #       begin: '(?<=\\{|\\,|^)\\s*(?![\\},])'
+  #       contentName: 'meta.structure.dictionary.key.python3'
+  #       end: '\\s*(?:(?=\\})|(\\:))'
+  #       endCaptures:
+  #         '1':
+  #           name: 'punctuation.separator.valuepair.dictionary.python3'
+  #       patterns: [
+  #         {
+  #           include: '$self'
+  #         }
+  #       ]
+  #     }
+  #     {
+  #       begin: '(?<=\\:|^)\\s*'
+  #       contentName: 'meta.structure.dictionary.value.python3'
+  #       end: '\\s*(?:(?=\\})|(,))'
+  #       endCaptures:
+  #         '1':
+  #           name: 'punctuation.separator.dictionary.python3'
+  #       patterns: [
+  #         {
+  #           include: '$self'
+  #         }
+  #       ]
+  #     }
+  #   ]
+  # }
+]

--- a/grammars/regular expressions (python3).cson
+++ b/grammars/regular expressions (python3).cson
@@ -1,0 +1,176 @@
+'comment': 'Matches Python\'s regular expression syntax.'
+'fileTypes': [
+  're'
+]
+'foldingStartMarker': '(/\\*|\\{|\\()'
+'foldingStopMarker': '(\\*/|\\}|\\))'
+'name': 'Regular Expressions (Python)'
+'patterns': [
+  {
+    'match': '\\\\[bBAZzG]|\\^|\\$'
+    'name': 'keyword.control.anchor.regexp'
+  }
+  {
+    match:'(\\\\")|(\\\\\')'
+    name: 'constant.character.escape.quote.regexp'
+  }
+  {
+    match: '\\\\(0[0-7]|[0-7]{3})'
+    name: 'constant.character.escape.octal.regex'
+  }
+  {
+    match: '\\\\x[[:xdigit:]]{2}'
+    name: 'constant.character.escape.hex.regexp'
+  }
+  {
+    match: '\\\\(u[[:xdigit:]]{4}|U[[:xdigit:]]{8})'
+    name: 'constant.character.escape.unicode.regex'
+  }
+  {
+    'match': '\\\\[.^$*+?|{}()\\[\\]\\\\]'
+    'name': 'constant.character.escape.operator.regexp'
+  }
+  {
+    'match': '\\\\[abfnrtv]'
+    'name': 'constant.character.escape.regexp'
+  }
+  {
+    'match': '\\\\[1-9][0-9]?'
+    'name': 'keyword.other.back-reference.regexp'
+  }
+  {
+    'match': '\\\\.'
+    'name': 'invalid.deprecated.backslash.regexp'
+  }
+  {
+    'match': '[?+*][?+]?|\\{(\\d+,\\d+|\\d+,|,\\d+|\\d+)\\}\\??'
+    'name': 'keyword.operator.quantifier.regexp'
+  }
+  {
+    'match': '\\|'
+    'name': 'keyword.operator.or.regexp'
+  }
+  {
+    'begin': '\\(\\?\\#'
+    'end': '\\)'
+    'name': 'comment.block.regexp'
+  }
+  {
+    'comment': 'We are restrictive in what we allow to go after the comment character to avoid false positives, since the availability of comments depend on regexp flags.'
+    'match': '(?<=^|\\s)#\\s[[a-zA-Z0-9,. \\t?!-:][^\\x{00}-\\x{7F}]]*$'
+    'name': 'comment.line.number-sign.regexp'
+  }
+  {
+    'match': '\\(\\?[iLmsux]+\\)'
+    'name': 'keyword.other.option-toggle.regexp'
+  }
+  {
+    'match': '(\\()(\\?P=([a-zA-Z_][a-zA-Z_0-9]*\\w*))(\\))'
+    'name': 'keyword.other.back-reference.named.regexp'
+  }
+  {
+    'begin': '(\\()((\\?=)|(\\?!)|(\\?<=)|(\\?<!))'
+    'beginCaptures':
+      '1':
+        'name': 'punctuation.definition.group.regexp'
+      '2':
+        'name': 'punctuation.definition.group.assertion.regexp'
+      '3':
+        'name': 'meta.assertion.look-ahead.regexp'
+      '4':
+        'name': 'meta.assertion.negative-look-ahead.regexp'
+      '5':
+        'name': 'meta.assertion.look-behind.regexp'
+      '6':
+        'name': 'meta.assertion.negative-look-behind.regexp'
+    'end': '(\\))'
+    'endCaptures':
+      '1':
+        'name': 'punctuation.definition.group.regexp'
+    'name': 'meta.group.assertion.regexp'
+    'patterns': [
+      {
+        'include': '$self'
+      }
+    ]
+  }
+  {
+    'begin': '(\\()(\\?\\(([1-9][0-9]?|[a-zA-Z_][a-zA-Z_0-9]*)\\))'
+    'beginCaptures':
+      '1':
+        'name': 'punctuation.definition.group.regexp'
+      '2':
+        'name': 'punctuation.definition.group.assertion.conditional.regexp'
+      '3':
+        'name': 'entity.name.section.back-reference.regexp'
+    'comment': 'we can make this more sophisticated to match the | character that separates yes-pattern from no-pattern, but it\'s not really necessary.'
+    'end': '(\\))'
+    'name': 'meta.group.assertion.conditional.regexp'
+    'patterns': [
+      {
+        'include': '$self'
+      }
+    ]
+  }
+  {
+    'begin': '(\\()((\\?P<)([a-z]\\w*)(>)|(\\?:))?'
+    'beginCaptures':
+      '1':
+        'name': 'punctuation.definition.group.regexp'
+      '3':
+        'name': 'punctuation.definition.group.capture.regexp'
+      '4':
+        'name': 'entity.name.section.group.regexp'
+      '5':
+        'name': 'punctuation.definition.group.capture.regexp'
+      '6':
+        'name': 'punctuation.definition.group.no-capture.regexp'
+    'end': '(\\))'
+    'endCaptures':
+      '1':
+        'name': 'punctuation.definition.group.regexp'
+    'name': 'meta.group.regexp'
+    'patterns': [
+      {
+        'include': '$self'
+      }
+    ]
+  }
+  {include: '#character-class'}
+]
+'repository':
+  'character-class':
+    'patterns': [
+      {
+        'match': '\\\\[wWsSdDhH]|\\.'
+        'name': 'constant.character.character-class.regexp'
+      }
+      {
+        'begin': '(\\[)(\\^)?'
+        'beginCaptures':
+          '1':
+            'name': 'punctuation.definition.character-class.regexp'
+          '2':
+            'name': 'keyword.operator.negation.regexp'
+        'end': '(\\])'
+        'endCaptures':
+          '1':
+            'name': 'punctuation.definition.character-class.regexp'
+        'name': 'constant.other.character-class.set.regexp'
+        'patterns': [
+          {
+            'include': '#character-class'
+          }
+          {
+            'captures':
+              '2':
+                'name': 'constant.character.escape.backslash.regexp'
+              '4':
+                'name': 'constant.character.escape.backslash.regexp'
+            'match': '((\\\\.)|.)\\-((\\\\.)|[^\\]])'
+            'name': 'constant.other.character-class.range.regexp'
+          }
+        ]
+      }
+    ]
+'scopeName': 'source.regexp.python3'

--- a/grammars/regular expressions (python3).cson
+++ b/grammars/regular expressions (python3).cson
@@ -1,176 +1,166 @@
-'comment': 'Matches Python\'s regular expression syntax.'
-'fileTypes': [
+comment: 'Matches Python\'s regular expression syntax.'
+name: 'Regular Expressions (Python)'
+scopeName: 'source.regexp.python.3'
+fileTypes: [
   're'
 ]
-'foldingStartMarker': '(/\\*|\\{|\\()'
-'foldingStopMarker': '(\\*/|\\}|\\))'
-'name': 'Regular Expressions (Python)'
-'patterns': [
+foldingStartMarker: '(/\\*|\\{|\\()'
+foldingStopMarker: '(\\*/|\\}|\\))'
+patterns: [
   {
-    'match': '\\\\[bBAZzG]|\\^|\\$'
-    'name': 'keyword.control.anchor.regexp'
+    match: '\\\\[bBAZzG]|\\^|\\$'
+    name: 'keyword.control.anchor.regexp'
   }
   {
-    match:'(\\\\")|(\\\\\')'
-    name: 'constant.character.escape.quote.regexp'
+    match: '\\\\[1-9][0-9]?'
+    name: 'keyword.other.back-reference.regexp'
+  }
+  {include: '#character_class'}
+  {include: '#escaped_char'}
+  {
+    match: '[?+*][?+]?|\\{(\\d+,\\d+|\\d+,|,\\d+|\\d+)\\}\\??'
+    name: 'keyword.operator.quantifier.regexp'
   }
   {
-    match: '\\\\(0[0-7]|[0-7]{3})'
-    name: 'constant.character.escape.octal.regex'
+    match: '\\|'
+    name: 'keyword.operator.or.regexp'
   }
   {
-    match: '\\\\x[[:xdigit:]]{2}'
-    name: 'constant.character.escape.hex.regexp'
+    begin: '\\(\\?\\#'
+    end: '\\)'
+    name: 'comment.block.regexp'
   }
   {
-    match: '\\\\(u[[:xdigit:]]{4}|U[[:xdigit:]]{8})'
-    name: 'constant.character.escape.unicode.regex'
+    comment: 'We are restrictive in what we allow to go after the comment character to avoid false positives, since the availability of comments depend on regexp flags.'
+    match: '(?<=^|\\s)#\\s[[a-zA-Z0-9,. \\t?!-:][^\\x{00}-\\x{7F}]]*$'
+    name: 'comment.line.number-sign.regexp'
   }
   {
-    'match': '\\\\[.^$*+?|{}()\\[\\]\\\\]'
-    'name': 'constant.character.escape.operator.regexp'
+    match: '\\(\\?[iLmsux]+\\)'
+    name: 'keyword.other.option-toggle.regexp'
   }
   {
-    'match': '\\\\[abfnrtv]'
-    'name': 'constant.character.escape.regexp'
+    match: '(\\()(\\?P=([a-zA-Z_][a-zA-Z_0-9]*\\w*))(\\))'
+    name: 'keyword.other.back-reference.named.regexp'
   }
   {
-    'match': '\\\\[1-9][0-9]?'
-    'name': 'keyword.other.back-reference.regexp'
-  }
-  {
-    'match': '\\\\.'
-    'name': 'invalid.deprecated.backslash.regexp'
-  }
-  {
-    'match': '[?+*][?+]?|\\{(\\d+,\\d+|\\d+,|,\\d+|\\d+)\\}\\??'
-    'name': 'keyword.operator.quantifier.regexp'
-  }
-  {
-    'match': '\\|'
-    'name': 'keyword.operator.or.regexp'
-  }
-  {
-    'begin': '\\(\\?\\#'
-    'end': '\\)'
-    'name': 'comment.block.regexp'
-  }
-  {
-    'comment': 'We are restrictive in what we allow to go after the comment character to avoid false positives, since the availability of comments depend on regexp flags.'
-    'match': '(?<=^|\\s)#\\s[[a-zA-Z0-9,. \\t?!-:][^\\x{00}-\\x{7F}]]*$'
-    'name': 'comment.line.number-sign.regexp'
-  }
-  {
-    'match': '\\(\\?[iLmsux]+\\)'
-    'name': 'keyword.other.option-toggle.regexp'
-  }
-  {
-    'match': '(\\()(\\?P=([a-zA-Z_][a-zA-Z_0-9]*\\w*))(\\))'
-    'name': 'keyword.other.back-reference.named.regexp'
-  }
-  {
-    'begin': '(\\()((\\?=)|(\\?!)|(\\?<=)|(\\?<!))'
-    'beginCaptures':
+    begin: '(\\()((\\?=)|(\\?!)|(\\?<=)|(\\?<!))'
+    beginCaptures:
       '1':
-        'name': 'punctuation.definition.group.regexp'
+        name: 'punctuation.definition.group.regexp'
       '2':
-        'name': 'punctuation.definition.group.assertion.regexp'
+        name: 'punctuation.definition.group.assertion.regexp'
       '3':
-        'name': 'meta.assertion.look-ahead.regexp'
+        name: 'meta.assertion.look-ahead.regexp'
       '4':
-        'name': 'meta.assertion.negative-look-ahead.regexp'
+        name: 'meta.assertion.negative-look-ahead.regexp'
       '5':
-        'name': 'meta.assertion.look-behind.regexp'
+        name: 'meta.assertion.look-behind.regexp'
       '6':
-        'name': 'meta.assertion.negative-look-behind.regexp'
-    'end': '(\\))'
-    'endCaptures':
+        name: 'meta.assertion.negative-look-behind.regexp'
+    end: '(\\))'
+    endCaptures:
       '1':
-        'name': 'punctuation.definition.group.regexp'
-    'name': 'meta.group.assertion.regexp'
-    'patterns': [
-      {
-        'include': '$self'
-      }
+        name: 'punctuation.definition.group.regexp'
+    name: 'meta.group.assertion.regexp'
+    patterns: [
+      {include: '$self'}
     ]
   }
   {
-    'begin': '(\\()(\\?\\(([1-9][0-9]?|[a-zA-Z_][a-zA-Z_0-9]*)\\))'
-    'beginCaptures':
+    begin: '(\\()(\\?\\(([1-9][0-9]?|[a-zA-Z_][a-zA-Z_0-9]*)\\))'
+    beginCaptures:
       '1':
-        'name': 'punctuation.definition.group.regexp'
+        name: 'punctuation.definition.group.regexp'
       '2':
-        'name': 'punctuation.definition.group.assertion.conditional.regexp'
+        name: 'punctuation.definition.group.assertion.conditional.regexp'
       '3':
-        'name': 'entity.name.section.back-reference.regexp'
-    'comment': 'we can make this more sophisticated to match the | character that separates yes-pattern from no-pattern, but it\'s not really necessary.'
-    'end': '(\\))'
-    'name': 'meta.group.assertion.conditional.regexp'
-    'patterns': [
-      {
-        'include': '$self'
-      }
+        name: 'entity.name.section.back-reference.regexp'
+    comment: 'we can make this more sophisticated to match the | character that separates yes-pattern from no-pattern, but it\'s not really necessary.'
+    end: '(\\))'
+    name: 'meta.group.assertion.conditional.regexp'
+    patterns: [
+      {include: '$self'}
     ]
   }
   {
-    'begin': '(\\()((\\?P<)([a-z]\\w*)(>)|(\\?:))?'
-    'beginCaptures':
+    begin: '(\\()((\\?P<)([a-z]\\w*)(>)|(\\?:))?'
+    beginCaptures:
       '1':
-        'name': 'punctuation.definition.group.regexp'
+        name: 'punctuation.definition.group.regexp'
       '3':
-        'name': 'punctuation.definition.group.capture.regexp'
+        name: 'punctuation.definition.group.capture.regexp'
       '4':
-        'name': 'entity.name.section.group.regexp'
+        name: 'entity.name.section.group.regexp'
       '5':
-        'name': 'punctuation.definition.group.capture.regexp'
+        name: 'punctuation.definition.group.capture.regexp'
       '6':
-        'name': 'punctuation.definition.group.no-capture.regexp'
-    'end': '(\\))'
-    'endCaptures':
+        name: 'punctuation.definition.group.no-capture.regexp'
+    end: '(\\))'
+    endCaptures:
       '1':
-        'name': 'punctuation.definition.group.regexp'
-    'name': 'meta.group.regexp'
-    'patterns': [
-      {
-        'include': '$self'
-      }
+        name: 'punctuation.definition.group.regexp'
+    name: 'meta.group.regexp'
+    patterns: [
+      {include: '$self'}
     ]
   }
-  {include: '#character-class'}
 ]
-'repository':
-  'character-class':
-    'patterns': [
+
+repository:
+  character_class:
+    patterns: [
       {
-        'match': '\\\\[wWsSdDhH]|\\.'
-        'name': 'constant.character.character-class.regexp'
+        match: '\\\\[wWsSdDhH]|\\.'
+        name: 'constant.character.character-class.regexp'
       }
       {
-        'begin': '(\\[)(\\^)?'
-        'beginCaptures':
+        begin: '(\\[)(\\^)?'
+        beginCaptures:
           '1':
-            'name': 'punctuation.definition.character-class.regexp'
+            name: 'punctuation.definition.character-class.regexp'
           '2':
-            'name': 'keyword.operator.negation.regexp'
-        'end': '(\\])'
-        'endCaptures':
+            name: 'keyword.operator.negation.regexp'
+        end: '(\\])'
+        endCaptures:
           '1':
-            'name': 'punctuation.definition.character-class.regexp'
-        'name': 'constant.other.character-class.set.regexp'
-        'patterns': [
-          {
-            'include': '#character-class'
-          }
-          {
-            'captures':
-              '2':
-                'name': 'constant.character.escape.backslash.regexp'
-              '4':
-                'name': 'constant.character.escape.backslash.regexp'
-            'match': '((\\\\.)|.)\\-((\\\\.)|[^\\]])'
-            'name': 'constant.other.character-class.range.regexp'
-          }
+            name: 'punctuation.definition.character-class.regexp'
+        name: 'constant.other.character-class.set.regexp'
+        patterns: [
+          {include: '#character-class'}
+          {include: '#escaped_char'}
         ]
       }
     ]
-'scopeName': 'source.regexp.python3'
+
+  escaped_char:
+    patterns: [
+      {
+        match:'(\\\\")|(\\\\\')'
+        name: 'constant.character.escape.quote.regexp'
+      }
+      {
+        match: '\\\\(0[0-7]|[0-7]{3})'
+        name: 'constant.character.escape.octal.regexp'
+      }
+      {
+        match: '\\\\x[[:xdigit:]]{2}'
+        name: 'constant.character.escape.hex.regexp'
+      }
+      {
+        match: '\\\\(u[[:xdigit:]]{4}|U[[:xdigit:]]{8})'
+        name: 'constant.character.escape.unicode.regexp'
+      }
+      {
+        match: '\\\\[.^$*+?|{}()\\[\\]\\\\]'
+        name: 'constant.character.escape.operator.regexp'
+      }
+      {
+        match: '\\\\[abfnrtv]'
+        name: 'constant.character.escape.regexp'
+      }
+      {
+        match: '\\\\.'
+        name: 'invalid.deprecated.backslash-escape.regexp'
+      }
+    ]

--- a/settings/language-python.cson
+++ b/settings/language-python.cson
@@ -7,13 +7,3 @@
     'commentStart': '# '
     'increaseIndentPattern': '^\\s*(class|def|elif|else|except|finally|for|if|try|with|while)\\b.*:\\s*$'
     'decreaseIndentPattern': '^\\s*(elif|else|except|finally)\\b.*:'
-
-'.source.python3':
-  editor:
-    autoIndentOnPaste: false
-    softTabs: true
-    tabLength: 4
-    foldEndPattern: '^\\s*"""\\s*$'
-    commentStart: '# '
-    increaseIndentPattern: '^\\s*(class|def|elif|else|except|finally|for|if|try|with|while)\\b.*:\\s*$'
-    decreaseIndentPattern: '^\\s*(elif|else|except|finally)\\b.*:'

--- a/settings/language-python.cson
+++ b/settings/language-python.cson
@@ -7,3 +7,13 @@
     'commentStart': '# '
     'increaseIndentPattern': '^\\s*(class|def|elif|else|except|finally|for|if|try|with|while)\\b.*:\\s*$'
     'decreaseIndentPattern': '^\\s*(elif|else|except|finally)\\b.*:'
+
+'.source.python3':
+  editor:
+    autoIndentOnPaste: false
+    softTabs: true
+    tabLength: 4
+    foldEndPattern: '^\\s*"""\\s*$'
+    commentStart: '# '
+    increaseIndentPattern: '^\\s*(class|def|elif|else|except|finally|for|if|try|with|while)\\b.*:\\s*$'
+    decreaseIndentPattern: '^\\s*(elif|else|except|finally)\\b.*:'

--- a/spec/python3-spec.coffee
+++ b/spec/python3-spec.coffee
@@ -6,33 +6,33 @@ describe "Python3 grammar", ->
       atom.packages.activatePackage("language-python")
 
     runs ->
-      grammar = atom.grammars.grammarForScopeName("source.python3")
+      grammar = atom.grammars.grammarForScopeName("source.python.3")
 
   it "parses the grammar", ->
     expect(grammar).toBeDefined()
-    expect(grammar.scopeName).toBe "source.python3"
+    expect(grammar.scopeName).toBe "source.python.3"
 
   it "tokenizes multi-line strings", ->
     tokens = grammar.tokenizeLines('"1\\\n2"')
 
     # Line 0
     expect(tokens[0][0].value).toBe '"'
-    expect(tokens[0][0].scopes).toEqual ['source.python3', 'string.quoted.double.single-line.unicode.python3', 'punctuation.definition.string.begin.python3']
+    expect(tokens[0][0].scopes).toEqual ['source.python.3', 'string.quoted.double.single-line.unicode.python.3', 'punctuation.definition.string.begin.python.3']
 
     expect(tokens[0][1].value).toBe '1'
-    expect(tokens[0][1].scopes).toEqual ['source.python3', 'string.quoted.double.single-line.unicode.python3']
+    expect(tokens[0][1].scopes).toEqual ['source.python.3', 'string.quoted.double.single-line.unicode.python.3']
 
     expect(tokens[0][2].value).toBe '\\'
-    expect(tokens[0][2].scopes).toEqual ['source.python3', 'string.quoted.double.single-line.unicode.python3', 'constant.character.escape.newline.python3']
+    expect(tokens[0][2].scopes).toEqual ['source.python.3', 'string.quoted.double.single-line.unicode.python.3', 'constant.character.escape.newline.python.3']
 
     expect(tokens[0][3]).not.toBeDefined()
 
     # Line 1
     expect(tokens[1][0].value).toBe '2'
-    expect(tokens[1][0].scopes).toEqual ['source.python3', 'string.quoted.double.single-line.unicode.python3']
+    expect(tokens[1][0].scopes).toEqual ['source.python.3', 'string.quoted.double.single-line.unicode.python.3']
 
     expect(tokens[1][1].value).toBe '"'
-    expect(tokens[1][1].scopes).toEqual ['source.python3', 'string.quoted.double.single-line.unicode.python3', 'punctuation.definition.string.end.python3']
+    expect(tokens[1][1].scopes).toEqual ['source.python.3', 'string.quoted.double.single-line.unicode.python.3', 'punctuation.definition.string.end.python.3']
 
     expect(tokens[1][2]).not.toBeDefined()
 
@@ -40,222 +40,222 @@ describe "Python3 grammar", ->
     tokens = grammar.tokenizeLines("r'%d(' #foo")
 
     expect(tokens[0][0].value).toBe 'r'
-    expect(tokens[0][0].scopes).toEqual ['source.python3', 'string.quoted.single.single-line.raw-unicode.python3', 'storage.type.string.python3']
+    expect(tokens[0][0].scopes).toEqual ['source.python.3', 'string.quoted.single.single-line.raw-unicode.python.3', 'storage.type.string.python.3']
     expect(tokens[0][1].value).toBe "'"
-    expect(tokens[0][1].scopes).toEqual ['source.python3', 'string.quoted.single.single-line.raw-unicode.python3', 'punctuation.definition.string.begin.python3']
+    expect(tokens[0][1].scopes).toEqual ['source.python.3', 'string.quoted.single.single-line.raw-unicode.python.3', 'punctuation.definition.string.begin.python.3']
     expect(tokens[0][2].value).toBe '%d'
-    expect(tokens[0][2].scopes).toEqual ['source.python3', 'string.quoted.single.single-line.raw-unicode.python3', 'constant.other.placeholder.printf.python3']
+    expect(tokens[0][2].scopes).toEqual ['source.python.3', 'string.quoted.single.single-line.raw-unicode.python.3', 'constant.other.placeholder.printf.python.3']
     expect(tokens[0][3].value).toBe '('
-    expect(tokens[0][3].scopes).toEqual ['source.python3', 'string.quoted.single.single-line.raw-unicode.python3', 'meta.group.regexp', 'punctuation.definition.group.regexp']
+    expect(tokens[0][3].scopes).toEqual ['source.python.3', 'string.quoted.single.single-line.raw-unicode.python.3', 'meta.group.regexp', 'punctuation.definition.group.regexp']
     expect(tokens[0][4].value).toBe "'"
-    expect(tokens[0][4].scopes).toEqual ['source.python3', 'string.quoted.single.single-line.raw-unicode.python3', 'punctuation.definition.string.end.python3']
+    expect(tokens[0][4].scopes).toEqual ['source.python.3', 'string.quoted.single.single-line.raw-unicode.python.3', 'punctuation.definition.string.end.python.3']
     expect(tokens[0][5].value).toBe ' '
-    expect(tokens[0][5].scopes).toEqual ['source.python3']
+    expect(tokens[0][5].scopes).toEqual ['source.python.3']
     expect(tokens[0][6].value).toBe '#'
-    expect(tokens[0][6].scopes).toEqual ['source.python3', 'comment.line.number-sign.python3', 'punctuation.definition.comment.python3']
+    expect(tokens[0][6].scopes).toEqual ['source.python.3', 'comment.line.number-sign.python.3', 'punctuation.definition.comment.python.3']
     expect(tokens[0][7].value).toBe 'foo'
-    expect(tokens[0][7].scopes).toEqual ['source.python3', 'comment.line.number-sign.python3']
+    expect(tokens[0][7].scopes).toEqual ['source.python.3', 'comment.line.number-sign.python.3']
 
   it "terminates a single-quoted raw string containing opening bracket at closing quote", ->
     tokens = grammar.tokenizeLines("r'%d[' #foo")
 
     expect(tokens[0][0].value).toBe 'r'
-    expect(tokens[0][0].scopes).toEqual ['source.python3', 'string.quoted.single.single-line.raw-unicode.python3', 'storage.type.string.python3']
+    expect(tokens[0][0].scopes).toEqual ['source.python.3', 'string.quoted.single.single-line.raw-unicode.python.3', 'storage.type.string.python.3']
     expect(tokens[0][1].value).toBe "'"
-    expect(tokens[0][1].scopes).toEqual ['source.python3', 'string.quoted.single.single-line.raw-unicode.python3', 'punctuation.definition.string.begin.python3']
+    expect(tokens[0][1].scopes).toEqual ['source.python.3', 'string.quoted.single.single-line.raw-unicode.python.3', 'punctuation.definition.string.begin.python.3']
     expect(tokens[0][2].value).toBe '%d'
-    expect(tokens[0][2].scopes).toEqual ['source.python3', 'string.quoted.single.single-line.raw-unicode.python3', 'constant.other.placeholder.printf.python3']
+    expect(tokens[0][2].scopes).toEqual ['source.python.3', 'string.quoted.single.single-line.raw-unicode.python.3', 'constant.other.placeholder.printf.python.3']
     expect(tokens[0][3].value).toBe '['
-    expect(tokens[0][3].scopes).toEqual ['source.python3', 'string.quoted.single.single-line.raw-unicode.python3', 'constant.other.character-class.set.regexp', 'punctuation.definition.character-class.regexp']
+    expect(tokens[0][3].scopes).toEqual ['source.python.3', 'string.quoted.single.single-line.raw-unicode.python.3', 'constant.other.character-class.set.regexp', 'punctuation.definition.character-class.regexp']
     expect(tokens[0][4].value).toBe "'"
-    expect(tokens[0][4].scopes).toEqual ['source.python3', 'string.quoted.single.single-line.raw-unicode.python3', 'punctuation.definition.string.end.python3']
+    expect(tokens[0][4].scopes).toEqual ['source.python.3', 'string.quoted.single.single-line.raw-unicode.python.3', 'punctuation.definition.string.end.python.3']
     expect(tokens[0][5].value).toBe ' '
-    expect(tokens[0][5].scopes).toEqual ['source.python3']
+    expect(tokens[0][5].scopes).toEqual ['source.python.3']
     expect(tokens[0][6].value).toBe '#'
-    expect(tokens[0][6].scopes).toEqual ['source.python3', 'comment.line.number-sign.python3', 'punctuation.definition.comment.python3']
+    expect(tokens[0][6].scopes).toEqual ['source.python.3', 'comment.line.number-sign.python.3', 'punctuation.definition.comment.python.3']
     expect(tokens[0][7].value).toBe 'foo'
-    expect(tokens[0][7].scopes).toEqual ['source.python3', 'comment.line.number-sign.python3']
+    expect(tokens[0][7].scopes).toEqual ['source.python.3', 'comment.line.number-sign.python.3']
 
   it "terminates a double-quoted raw string containing opening parenthesis at closing quote", ->
     tokens = grammar.tokenizeLines('r"%d(" #foo')
 
     expect(tokens[0][0].value).toBe 'r'
-    expect(tokens[0][0].scopes).toEqual ['source.python3', 'string.quoted.double.single-line.raw-unicode.python3', 'storage.type.string.python3']
+    expect(tokens[0][0].scopes).toEqual ['source.python.3', 'string.quoted.double.single-line.raw-unicode.python.3', 'storage.type.string.python.3']
     expect(tokens[0][1].value).toBe '"'
-    expect(tokens[0][1].scopes).toEqual ['source.python3', 'string.quoted.double.single-line.raw-unicode.python3', 'punctuation.definition.string.begin.python3']
+    expect(tokens[0][1].scopes).toEqual ['source.python.3', 'string.quoted.double.single-line.raw-unicode.python.3', 'punctuation.definition.string.begin.python.3']
     expect(tokens[0][2].value).toBe '%d'
-    expect(tokens[0][2].scopes).toEqual ['source.python3', 'string.quoted.double.single-line.raw-unicode.python3', 'constant.other.placeholder.printf.python3']
+    expect(tokens[0][2].scopes).toEqual ['source.python.3', 'string.quoted.double.single-line.raw-unicode.python.3', 'constant.other.placeholder.printf.python.3']
     expect(tokens[0][3].value).toBe '('
-    expect(tokens[0][3].scopes).toEqual ['source.python3', 'string.quoted.double.single-line.raw-unicode.python3', 'meta.group.regexp', 'punctuation.definition.group.regexp']
+    expect(tokens[0][3].scopes).toEqual ['source.python.3', 'string.quoted.double.single-line.raw-unicode.python.3', 'meta.group.regexp', 'punctuation.definition.group.regexp']
     expect(tokens[0][4].value).toBe '"'
-    expect(tokens[0][4].scopes).toEqual ['source.python3', 'string.quoted.double.single-line.raw-unicode.python3', 'punctuation.definition.string.end.python3']
+    expect(tokens[0][4].scopes).toEqual ['source.python.3', 'string.quoted.double.single-line.raw-unicode.python.3', 'punctuation.definition.string.end.python.3']
     expect(tokens[0][5].value).toBe ' '
-    expect(tokens[0][5].scopes).toEqual ['source.python3']
+    expect(tokens[0][5].scopes).toEqual ['source.python.3']
     expect(tokens[0][6].value).toBe '#'
-    expect(tokens[0][6].scopes).toEqual ['source.python3', 'comment.line.number-sign.python3', 'punctuation.definition.comment.python3']
+    expect(tokens[0][6].scopes).toEqual ['source.python.3', 'comment.line.number-sign.python.3', 'punctuation.definition.comment.python.3']
     expect(tokens[0][7].value).toBe 'foo'
-    expect(tokens[0][7].scopes).toEqual ['source.python3', 'comment.line.number-sign.python3']
+    expect(tokens[0][7].scopes).toEqual ['source.python.3', 'comment.line.number-sign.python.3']
 
   it "terminates a double-quoted raw string containing opening bracket at closing quote", ->
     tokens = grammar.tokenizeLines('r"%d[" #foo')
 
     expect(tokens[0][0].value).toBe 'r'
-    expect(tokens[0][0].scopes).toEqual ['source.python3', 'string.quoted.double.single-line.raw-unicode.python3', 'storage.type.string.python3']
+    expect(tokens[0][0].scopes).toEqual ['source.python.3', 'string.quoted.double.single-line.raw-unicode.python.3', 'storage.type.string.python.3']
     expect(tokens[0][1].value).toBe '"'
-    expect(tokens[0][1].scopes).toEqual ['source.python3', 'string.quoted.double.single-line.raw-unicode.python3', 'punctuation.definition.string.begin.python3']
+    expect(tokens[0][1].scopes).toEqual ['source.python.3', 'string.quoted.double.single-line.raw-unicode.python.3', 'punctuation.definition.string.begin.python.3']
     expect(tokens[0][2].value).toBe '%d'
-    expect(tokens[0][2].scopes).toEqual ['source.python3', 'string.quoted.double.single-line.raw-unicode.python3', 'constant.other.placeholder.printf.python3']
+    expect(tokens[0][2].scopes).toEqual ['source.python.3', 'string.quoted.double.single-line.raw-unicode.python.3', 'constant.other.placeholder.printf.python.3']
     expect(tokens[0][3].value).toBe '['
-    expect(tokens[0][3].scopes).toEqual ['source.python3', 'string.quoted.double.single-line.raw-unicode.python3', 'constant.other.character-class.set.regexp', 'punctuation.definition.character-class.regexp']
+    expect(tokens[0][3].scopes).toEqual ['source.python.3', 'string.quoted.double.single-line.raw-unicode.python.3', 'constant.other.character-class.set.regexp', 'punctuation.definition.character-class.regexp']
     expect(tokens[0][4].value).toBe '"'
-    expect(tokens[0][4].scopes).toEqual ['source.python3', 'string.quoted.double.single-line.raw-unicode.python3', 'punctuation.definition.string.end.python3']
+    expect(tokens[0][4].scopes).toEqual ['source.python.3', 'string.quoted.double.single-line.raw-unicode.python.3', 'punctuation.definition.string.end.python.3']
     expect(tokens[0][5].value).toBe ' '
-    expect(tokens[0][5].scopes).toEqual ['source.python3']
+    expect(tokens[0][5].scopes).toEqual ['source.python.3']
     expect(tokens[0][6].value).toBe '#'
-    expect(tokens[0][6].scopes).toEqual ['source.python3', 'comment.line.number-sign.python3', 'punctuation.definition.comment.python3']
+    expect(tokens[0][6].scopes).toEqual ['source.python.3', 'comment.line.number-sign.python.3', 'punctuation.definition.comment.python.3']
     expect(tokens[0][7].value).toBe 'foo'
-    expect(tokens[0][7].scopes).toEqual ['source.python3', 'comment.line.number-sign.python3']
+    expect(tokens[0][7].scopes).toEqual ['source.python.3', 'comment.line.number-sign.python.3']
 
   it "terminates a bytes single-quoted raw string containing opening parenthesis at closing quote", ->
     tokens = grammar.tokenizeLines("br'%d(' #foo")
 
     expect(tokens[0][0].value).toBe 'br'
-    expect(tokens[0][0].scopes).toEqual ['source.python3', 'string.quoted.single.single-line.raw-bytes.python3', 'storage.type.string.python3']
+    expect(tokens[0][0].scopes).toEqual ['source.python.3', 'string.quoted.single.single-line.raw-bytes.python.3', 'storage.type.string.python.3']
     expect(tokens[0][1].value).toBe "'"
-    expect(tokens[0][1].scopes).toEqual ['source.python3', 'string.quoted.single.single-line.raw-bytes.python3', 'punctuation.definition.string.begin.python3']
+    expect(tokens[0][1].scopes).toEqual ['source.python.3', 'string.quoted.single.single-line.raw-bytes.python.3', 'punctuation.definition.string.begin.python.3']
     expect(tokens[0][2].value).toBe '%d'
-    expect(tokens[0][2].scopes).toEqual ['source.python3', 'string.quoted.single.single-line.raw-bytes.python3', 'constant.other.placeholder.printf.python3']
+    expect(tokens[0][2].scopes).toEqual ['source.python.3', 'string.quoted.single.single-line.raw-bytes.python.3', 'constant.other.placeholder.printf.python.3']
     expect(tokens[0][3].value).toBe '('
-    expect(tokens[0][3].scopes).toEqual ['source.python3', 'string.quoted.single.single-line.raw-bytes.python3', 'meta.group.regexp', 'punctuation.definition.group.regexp']
+    expect(tokens[0][3].scopes).toEqual ['source.python.3', 'string.quoted.single.single-line.raw-bytes.python.3', 'meta.group.regexp', 'punctuation.definition.group.regexp']
     expect(tokens[0][4].value).toBe "'"
-    expect(tokens[0][4].scopes).toEqual ['source.python3', 'string.quoted.single.single-line.raw-bytes.python3', 'punctuation.definition.string.end.python3']
+    expect(tokens[0][4].scopes).toEqual ['source.python.3', 'string.quoted.single.single-line.raw-bytes.python.3', 'punctuation.definition.string.end.python.3']
     expect(tokens[0][5].value).toBe ' '
-    expect(tokens[0][5].scopes).toEqual ['source.python3']
+    expect(tokens[0][5].scopes).toEqual ['source.python.3']
     expect(tokens[0][6].value).toBe '#'
-    expect(tokens[0][6].scopes).toEqual ['source.python3', 'comment.line.number-sign.python3', 'punctuation.definition.comment.python3']
+    expect(tokens[0][6].scopes).toEqual ['source.python.3', 'comment.line.number-sign.python.3', 'punctuation.definition.comment.python.3']
     expect(tokens[0][7].value).toBe 'foo'
-    expect(tokens[0][7].scopes).toEqual ['source.python3', 'comment.line.number-sign.python3']
+    expect(tokens[0][7].scopes).toEqual ['source.python.3', 'comment.line.number-sign.python.3']
 
   it "terminates a bytes single-quoted raw string containing opening bracket at closing quote", ->
     tokens = grammar.tokenizeLines("br'%d[' #foo")
 
     expect(tokens[0][0].value).toBe 'br'
-    expect(tokens[0][0].scopes).toEqual ['source.python3', 'string.quoted.single.single-line.raw-bytes.python3', 'storage.type.string.python3']
+    expect(tokens[0][0].scopes).toEqual ['source.python.3', 'string.quoted.single.single-line.raw-bytes.python.3', 'storage.type.string.python.3']
     expect(tokens[0][1].value).toBe "'"
-    expect(tokens[0][1].scopes).toEqual ['source.python3', 'string.quoted.single.single-line.raw-bytes.python3', 'punctuation.definition.string.begin.python3']
+    expect(tokens[0][1].scopes).toEqual ['source.python.3', 'string.quoted.single.single-line.raw-bytes.python.3', 'punctuation.definition.string.begin.python.3']
     expect(tokens[0][2].value).toBe '%d'
-    expect(tokens[0][2].scopes).toEqual ['source.python3', 'string.quoted.single.single-line.raw-bytes.python3', 'constant.other.placeholder.printf.python3']
+    expect(tokens[0][2].scopes).toEqual ['source.python.3', 'string.quoted.single.single-line.raw-bytes.python.3', 'constant.other.placeholder.printf.python.3']
     expect(tokens[0][3].value).toBe '['
-    expect(tokens[0][3].scopes).toEqual ['source.python3', 'string.quoted.single.single-line.raw-bytes.python3', 'constant.other.character-class.set.regexp', 'punctuation.definition.character-class.regexp']
+    expect(tokens[0][3].scopes).toEqual ['source.python.3', 'string.quoted.single.single-line.raw-bytes.python.3', 'constant.other.character-class.set.regexp', 'punctuation.definition.character-class.regexp']
     expect(tokens[0][4].value).toBe "'"
-    expect(tokens[0][4].scopes).toEqual ['source.python3', 'string.quoted.single.single-line.raw-bytes.python3', 'punctuation.definition.string.end.python3']
+    expect(tokens[0][4].scopes).toEqual ['source.python.3', 'string.quoted.single.single-line.raw-bytes.python.3', 'punctuation.definition.string.end.python.3']
     expect(tokens[0][5].value).toBe ' '
-    expect(tokens[0][5].scopes).toEqual ['source.python3']
+    expect(tokens[0][5].scopes).toEqual ['source.python.3']
     expect(tokens[0][6].value).toBe '#'
-    expect(tokens[0][6].scopes).toEqual ['source.python3', 'comment.line.number-sign.python3', 'punctuation.definition.comment.python3']
+    expect(tokens[0][6].scopes).toEqual ['source.python.3', 'comment.line.number-sign.python.3', 'punctuation.definition.comment.python.3']
     expect(tokens[0][7].value).toBe 'foo'
-    expect(tokens[0][7].scopes).toEqual ['source.python3', 'comment.line.number-sign.python3']
+    expect(tokens[0][7].scopes).toEqual ['source.python.3', 'comment.line.number-sign.python.3']
 
   it "terminates a bytes double-quoted raw string containing opening parenthesis at closing quote", ->
     tokens = grammar.tokenizeLines('br"%d(" #foo')
 
     expect(tokens[0][0].value).toBe 'br'
-    expect(tokens[0][0].scopes).toEqual ['source.python3', 'string.quoted.double.single-line.raw-bytes.python3', 'storage.type.string.python3']
+    expect(tokens[0][0].scopes).toEqual ['source.python.3', 'string.quoted.double.single-line.raw-bytes.python.3', 'storage.type.string.python.3']
     expect(tokens[0][1].value).toBe '"'
-    expect(tokens[0][1].scopes).toEqual ['source.python3', 'string.quoted.double.single-line.raw-bytes.python3', 'punctuation.definition.string.begin.python3']
+    expect(tokens[0][1].scopes).toEqual ['source.python.3', 'string.quoted.double.single-line.raw-bytes.python.3', 'punctuation.definition.string.begin.python.3']
     expect(tokens[0][2].value).toBe '%d'
-    expect(tokens[0][2].scopes).toEqual ['source.python3', 'string.quoted.double.single-line.raw-bytes.python3', 'constant.other.placeholder.printf.python3']
+    expect(tokens[0][2].scopes).toEqual ['source.python.3', 'string.quoted.double.single-line.raw-bytes.python.3', 'constant.other.placeholder.printf.python.3']
     expect(tokens[0][3].value).toBe '('
-    expect(tokens[0][3].scopes).toEqual ['source.python3', 'string.quoted.double.single-line.raw-bytes.python3', 'meta.group.regexp', 'punctuation.definition.group.regexp']
+    expect(tokens[0][3].scopes).toEqual ['source.python.3', 'string.quoted.double.single-line.raw-bytes.python.3', 'meta.group.regexp', 'punctuation.definition.group.regexp']
     expect(tokens[0][4].value).toBe '"'
-    expect(tokens[0][4].scopes).toEqual ['source.python3', 'string.quoted.double.single-line.raw-bytes.python3', 'punctuation.definition.string.end.python3']
+    expect(tokens[0][4].scopes).toEqual ['source.python.3', 'string.quoted.double.single-line.raw-bytes.python.3', 'punctuation.definition.string.end.python.3']
     expect(tokens[0][5].value).toBe ' '
-    expect(tokens[0][5].scopes).toEqual ['source.python3']
+    expect(tokens[0][5].scopes).toEqual ['source.python.3']
     expect(tokens[0][6].value).toBe '#'
-    expect(tokens[0][6].scopes).toEqual ['source.python3', 'comment.line.number-sign.python3', 'punctuation.definition.comment.python3']
+    expect(tokens[0][6].scopes).toEqual ['source.python.3', 'comment.line.number-sign.python.3', 'punctuation.definition.comment.python.3']
     expect(tokens[0][7].value).toBe 'foo'
-    expect(tokens[0][7].scopes).toEqual ['source.python3', 'comment.line.number-sign.python3']
+    expect(tokens[0][7].scopes).toEqual ['source.python.3', 'comment.line.number-sign.python.3']
 
   it "terminates a bytes double-quoted raw string containing opening bracket at closing quote", ->
     tokens = grammar.tokenizeLines('br"%d[" #foo')
 
     expect(tokens[0][0].value).toBe 'br'
-    expect(tokens[0][0].scopes).toEqual ['source.python3', 'string.quoted.double.single-line.raw-bytes.python3', 'storage.type.string.python3']
+    expect(tokens[0][0].scopes).toEqual ['source.python.3', 'string.quoted.double.single-line.raw-bytes.python.3', 'storage.type.string.python.3']
     expect(tokens[0][1].value).toBe '"'
-    expect(tokens[0][1].scopes).toEqual ['source.python3', 'string.quoted.double.single-line.raw-bytes.python3', 'punctuation.definition.string.begin.python3']
+    expect(tokens[0][1].scopes).toEqual ['source.python.3', 'string.quoted.double.single-line.raw-bytes.python.3', 'punctuation.definition.string.begin.python.3']
     expect(tokens[0][2].value).toBe '%d'
-    expect(tokens[0][2].scopes).toEqual ['source.python3', 'string.quoted.double.single-line.raw-bytes.python3', 'constant.other.placeholder.printf.python3']
+    expect(tokens[0][2].scopes).toEqual ['source.python.3', 'string.quoted.double.single-line.raw-bytes.python.3', 'constant.other.placeholder.printf.python.3']
     expect(tokens[0][3].value).toBe '['
-    expect(tokens[0][3].scopes).toEqual ['source.python3', 'string.quoted.double.single-line.raw-bytes.python3', 'constant.other.character-class.set.regexp', 'punctuation.definition.character-class.regexp']
+    expect(tokens[0][3].scopes).toEqual ['source.python.3', 'string.quoted.double.single-line.raw-bytes.python.3', 'constant.other.character-class.set.regexp', 'punctuation.definition.character-class.regexp']
     expect(tokens[0][4].value).toBe '"'
-    expect(tokens[0][4].scopes).toEqual ['source.python3', 'string.quoted.double.single-line.raw-bytes.python3', 'punctuation.definition.string.end.python3']
+    expect(tokens[0][4].scopes).toEqual ['source.python.3', 'string.quoted.double.single-line.raw-bytes.python.3', 'punctuation.definition.string.end.python.3']
     expect(tokens[0][5].value).toBe ' '
-    expect(tokens[0][5].scopes).toEqual ['source.python3']
+    expect(tokens[0][5].scopes).toEqual ['source.python.3']
     expect(tokens[0][6].value).toBe '#'
-    expect(tokens[0][6].scopes).toEqual ['source.python3', 'comment.line.number-sign.python3', 'punctuation.definition.comment.python3']
+    expect(tokens[0][6].scopes).toEqual ['source.python.3', 'comment.line.number-sign.python.3', 'punctuation.definition.comment.python.3']
     expect(tokens[0][7].value).toBe 'foo'
-    expect(tokens[0][7].scopes).toEqual ['source.python3', 'comment.line.number-sign.python3']
+    expect(tokens[0][7].scopes).toEqual ['source.python.3', 'comment.line.number-sign.python.3']
 
   it "terminates referencing an item in a list variable after a sequence of a closing and opening bracket", ->
     tokens = grammar.tokenizeLines('foo[i[0]][j[0]]')
 
     expect(tokens[0][0].value).toBe 'foo'
-    expect(tokens[0][0].scopes).toEqual ['source.python3', 'meta.item-access.python3']
+    expect(tokens[0][0].scopes).toEqual ['source.python.3', 'meta.item-access.python.3']
     expect(tokens[0][1].value).toBe '['
-    expect(tokens[0][1].scopes).toEqual ['source.python3', 'meta.item-access.python3', 'punctuation.definition.arguments.begin.python3']
+    expect(tokens[0][1].scopes).toEqual ['source.python.3', 'meta.item-access.python.3', 'punctuation.definition.arguments.begin.python.3']
     expect(tokens[0][2].value).toBe 'i'
-    expect(tokens[0][2].scopes).toEqual ['source.python3', 'meta.item-access.python3', 'meta.item-access.arguments.python3', 'meta.item-access.python3']
+    expect(tokens[0][2].scopes).toEqual ['source.python.3', 'meta.item-access.python.3', 'meta.item-access.arguments.python.3', 'meta.item-access.python.3']
     expect(tokens[0][3].value).toBe '['
-    expect(tokens[0][3].scopes).toEqual ['source.python3', 'meta.item-access.python3', 'meta.item-access.arguments.python3', 'meta.item-access.python3', 'punctuation.definition.arguments.begin.python3']
+    expect(tokens[0][3].scopes).toEqual ['source.python.3', 'meta.item-access.python.3', 'meta.item-access.arguments.python.3', 'meta.item-access.python.3', 'punctuation.definition.arguments.begin.python.3']
     expect(tokens[0][4].value).toBe '0'
-    expect(tokens[0][4].scopes).toEqual ['source.python3', 'meta.item-access.python3', 'meta.item-access.arguments.python3', 'meta.item-access.python3', 'meta.item-access.arguments.python3', 'constant.numeric.integer.decimal.python3']
+    expect(tokens[0][4].scopes).toEqual ['source.python.3', 'meta.item-access.python.3', 'meta.item-access.arguments.python.3', 'meta.item-access.python.3', 'meta.item-access.arguments.python.3', 'constant.numeric.integer.decimal.python.3']
     expect(tokens[0][5].value).toBe ']'
-    expect(tokens[0][5].scopes).toEqual ['source.python3', 'meta.item-access.python3', 'meta.item-access.arguments.python3', 'meta.item-access.python3', 'punctuation.definition.arguments.end.python3']
+    expect(tokens[0][5].scopes).toEqual ['source.python.3', 'meta.item-access.python.3', 'meta.item-access.arguments.python.3', 'meta.item-access.python.3', 'punctuation.definition.arguments.end.python.3']
     expect(tokens[0][6].value).toBe ']'
-    expect(tokens[0][6].scopes).toEqual ['source.python3', 'meta.item-access.python3', 'punctuation.definition.arguments.end.python3']
+    expect(tokens[0][6].scopes).toEqual ['source.python.3', 'meta.item-access.python.3', 'punctuation.definition.arguments.end.python.3']
     expect(tokens[0][7].value).toBe '['
-    expect(tokens[0][7].scopes).toEqual ['source.python3', 'meta.structure.list.python3', 'punctuation.definition.list.begin.python3']
+    expect(tokens[0][7].scopes).toEqual ['source.python.3', 'meta.structure.list.python.3', 'punctuation.definition.list.begin.python.3']
     expect(tokens[0][8].value).toBe 'j'
-    expect(tokens[0][8].scopes).toEqual ['source.python3', 'meta.structure.list.python3', 'meta.structure.list.item.python3', 'meta.item-access.python3']
+    expect(tokens[0][8].scopes).toEqual ['source.python.3', 'meta.structure.list.python.3', 'meta.structure.list.item.python.3', 'meta.item-access.python.3']
     expect(tokens[0][9].value).toBe '['
-    expect(tokens[0][9].scopes).toEqual ['source.python3', 'meta.structure.list.python3', 'meta.structure.list.item.python3', 'meta.item-access.python3', 'punctuation.definition.arguments.begin.python3']
+    expect(tokens[0][9].scopes).toEqual ['source.python.3', 'meta.structure.list.python.3', 'meta.structure.list.item.python.3', 'meta.item-access.python.3', 'punctuation.definition.arguments.begin.python.3']
     expect(tokens[0][10].value).toBe '0'
-    expect(tokens[0][10].scopes).toEqual ['source.python3', 'meta.structure.list.python3', 'meta.structure.list.item.python3', 'meta.item-access.python3', 'meta.item-access.arguments.python3', 'constant.numeric.integer.decimal.python3']
+    expect(tokens[0][10].scopes).toEqual ['source.python.3', 'meta.structure.list.python.3', 'meta.structure.list.item.python.3', 'meta.item-access.python.3', 'meta.item-access.arguments.python.3', 'constant.numeric.integer.decimal.python.3']
     expect(tokens[0][11].value).toBe ']'
-    expect(tokens[0][11].scopes).toEqual ['source.python3', 'meta.structure.list.python3', 'meta.structure.list.item.python3', 'meta.item-access.python3', 'punctuation.definition.arguments.end.python3']
+    expect(tokens[0][11].scopes).toEqual ['source.python.3', 'meta.structure.list.python.3', 'meta.structure.list.item.python.3', 'meta.item-access.python.3', 'punctuation.definition.arguments.end.python.3']
     expect(tokens[0][12].value).toBe ']'
-    expect(tokens[0][12].scopes).toEqual ['source.python3', 'meta.structure.list.python3', 'punctuation.definition.list.end.python3']
+    expect(tokens[0][12].scopes).toEqual ['source.python.3', 'meta.structure.list.python.3', 'punctuation.definition.list.end.python.3']
 
   it "tokenizes properties of self as variables", ->
     tokens = grammar.tokenizeLines('self.foo')
 
     expect(tokens[0][0].value).toBe 'self'
-    expect(tokens[0][0].scopes).toEqual ['source.python3', 'variable.language.python3']
+    expect(tokens[0][0].scopes).toEqual ['source.python.3', 'variable.language.python.3']
     expect(tokens[0][1].value).toBe '.'
-    expect(tokens[0][1].scopes).toEqual ['source.python3']
+    expect(tokens[0][1].scopes).toEqual ['source.python.3']
     expect(tokens[0][2].value).toBe 'foo'
-    expect(tokens[0][2].scopes).toEqual ['source.python3']
+    expect(tokens[0][2].scopes).toEqual ['source.python.3']
 
   it "tokenizes properties of a variable as variables", ->
     tokens = grammar.tokenizeLines('bar.foo')
 
     expect(tokens[0][0].value).toBe 'bar'
-    expect(tokens[0][0].scopes).toEqual ['source.python3']
+    expect(tokens[0][0].scopes).toEqual ['source.python.3']
     expect(tokens[0][1].value).toBe '.'
-    expect(tokens[0][1].scopes).toEqual ['source.python3']
+    expect(tokens[0][1].scopes).toEqual ['source.python.3']
     expect(tokens[0][2].value).toBe 'foo'
-    expect(tokens[0][2].scopes).toEqual ['source.python3']
+    expect(tokens[0][2].scopes).toEqual ['source.python.3']
 
   it "tokenizes comments inside function parameters", ->
     {tokens} = grammar.tokenizeLine('def test(arg, # comment')
 
-    expect(tokens[0]).toEqual value: 'def', scopes: ['source.python3', 'meta.function.python3', 'storage.type.function.python3']
-    expect(tokens[2]).toEqual value: 'test', scopes: ['source.python3', 'meta.function.python3', 'entity.name.function.python3']
-    expect(tokens[3]).toEqual value: '(', scopes: ['source.python3', 'meta.function.python3', 'punctuation.definition.parameters.begin.python3']
-    expect(tokens[4]).toEqual value: 'arg', scopes: ['source.python3', 'meta.function.python3', 'meta.function.parameters.python3', 'variable.parameter.function.python3']
-    expect(tokens[5]).toEqual value: ',', scopes: ['source.python3', 'meta.function.python3', 'meta.function.parameters.python3', 'punctuation.separator.parameters.python3']
-    expect(tokens[7]).toEqual value: '#', scopes: ['source.python3', 'meta.function.python3', 'meta.function.parameters.python3', 'comment.line.number-sign.python3', 'punctuation.definition.comment.python3']
-    expect(tokens[8]).toEqual value: ' comment', scopes: ['source.python3', 'meta.function.python3', 'meta.function.parameters.python3', 'comment.line.number-sign.python3']
+    expect(tokens[0]).toEqual value: 'def', scopes: ['source.python.3', 'meta.function.python.3', 'storage.type.function.python.3']
+    expect(tokens[2]).toEqual value: 'test', scopes: ['source.python.3', 'meta.function.python.3', 'entity.name.function.python.3']
+    expect(tokens[3]).toEqual value: '(', scopes: ['source.python.3', 'meta.function.python.3', 'punctuation.definition.parameters.begin.python.3']
+    expect(tokens[4]).toEqual value: 'arg', scopes: ['source.python.3', 'meta.function.python.3', 'meta.function.parameters.python.3', 'variable.parameter.function.python.3']
+    expect(tokens[5]).toEqual value: ',', scopes: ['source.python.3', 'meta.function.python.3', 'meta.function.parameters.python.3', 'punctuation.separator.parameters.python.3']
+    expect(tokens[7]).toEqual value: '#', scopes: ['source.python.3', 'meta.function.python.3', 'meta.function.parameters.python.3', 'comment.line.number-sign.python.3', 'punctuation.definition.comment.python.3']
+    expect(tokens[8]).toEqual value: ' comment', scopes: ['source.python.3', 'meta.function.python.3', 'meta.function.parameters.python.3', 'comment.line.number-sign.python.3']
 
     tokens = grammar.tokenizeLines("""
       def __init__(
@@ -265,24 +265,24 @@ describe "Python3 grammar", ->
       ):
     """)
 
-    expect(tokens[0][0]).toEqual value: 'def', scopes: ['source.python3', 'meta.function.python3', 'storage.type.function.python3']
-    expect(tokens[0][2]).toEqual value: '__init__', scopes: ['source.python3', 'meta.function.python3', 'entity.name.function.python3', 'support.function.magic.python3']
-    expect(tokens[0][3]).toEqual value: '(', scopes: ['source.python3', 'meta.function.python3', 'punctuation.definition.parameters.begin.python3']
-    expect(tokens[1][1]).toEqual value: 'self', scopes: ['source.python3', 'meta.function.python3', 'meta.function.parameters.python3', 'variable.parameter.function.python3']
-    expect(tokens[1][2]).toEqual value: ',', scopes: ['source.python3', 'meta.function.python3', 'meta.function.parameters.python3', 'punctuation.separator.parameters.python3']
-    expect(tokens[2][1]).toEqual value: 'codec', scopes: ['source.python3', 'meta.function.python3', 'meta.function.parameters.python3', 'variable.parameter.function.python3']
-    expect(tokens[2][2]).toEqual value: ',', scopes: ['source.python3', 'meta.function.python3', 'meta.function.parameters.python3', 'punctuation.separator.parameters.python3']
-    expect(tokens[2][4]).toEqual value: '#', scopes: ['source.python3', 'meta.function.python3', 'meta.function.parameters.python3', 'comment.line.number-sign.python3', 'punctuation.definition.comment.python3']
-    expect(tokens[2][5]).toEqual value: ' comment', scopes: ['source.python3', 'meta.function.python3', 'meta.function.parameters.python3', 'comment.line.number-sign.python3']
-    expect(tokens[3][1]).toEqual value: 'config', scopes: ['source.python3', 'meta.function.python3', 'meta.function.parameters.python3', 'variable.parameter.function.python3']
-    expect(tokens[4][0]).toEqual value: ')', scopes: ['source.python3', 'meta.function.python3', 'punctuation.definition.parameters.end.python3']
-    expect(tokens[4][1]).toEqual value: ':', scopes: ['source.python3', 'meta.function.python3', 'punctuation.section.function.begin.python3']
+    expect(tokens[0][0]).toEqual value: 'def', scopes: ['source.python.3', 'meta.function.python.3', 'storage.type.function.python.3']
+    expect(tokens[0][2]).toEqual value: '__init__', scopes: ['source.python.3', 'meta.function.python.3', 'entity.name.function.python.3', 'support.function.magic.python.3']
+    expect(tokens[0][3]).toEqual value: '(', scopes: ['source.python.3', 'meta.function.python.3', 'punctuation.definition.parameters.begin.python.3']
+    expect(tokens[1][1]).toEqual value: 'self', scopes: ['source.python.3', 'meta.function.python.3', 'meta.function.parameters.python.3', 'variable.parameter.function.python.3']
+    expect(tokens[1][2]).toEqual value: ',', scopes: ['source.python.3', 'meta.function.python.3', 'meta.function.parameters.python.3', 'punctuation.separator.parameters.python.3']
+    expect(tokens[2][1]).toEqual value: 'codec', scopes: ['source.python.3', 'meta.function.python.3', 'meta.function.parameters.python.3', 'variable.parameter.function.python.3']
+    expect(tokens[2][2]).toEqual value: ',', scopes: ['source.python.3', 'meta.function.python.3', 'meta.function.parameters.python.3', 'punctuation.separator.parameters.python.3']
+    expect(tokens[2][4]).toEqual value: '#', scopes: ['source.python.3', 'meta.function.python.3', 'meta.function.parameters.python.3', 'comment.line.number-sign.python.3', 'punctuation.definition.comment.python.3']
+    expect(tokens[2][5]).toEqual value: ' comment', scopes: ['source.python.3', 'meta.function.python.3', 'meta.function.parameters.python.3', 'comment.line.number-sign.python.3']
+    expect(tokens[3][1]).toEqual value: 'config', scopes: ['source.python.3', 'meta.function.python.3', 'meta.function.parameters.python.3', 'variable.parameter.function.python.3']
+    expect(tokens[4][0]).toEqual value: ')', scopes: ['source.python.3', 'meta.function.python.3', 'punctuation.definition.parameters.end.python.3']
+    expect(tokens[4][1]).toEqual value: ':', scopes: ['source.python.3', 'meta.function.python.3', 'punctuation.section.function.begin.python.3']
 
 
   # it "tokenizes SQL inline highlighting on blocks", ->
   #   delimsByScope =
-  #     "string.quoted.double.block.sql.python3": '"""'
-  #     "string.quoted.single.block.sql.python3": "'''"
+  #     "string.quoted.double.block.sql.python.3": '"""'
+  #     "string.quoted.single.block.sql.python.3": "'''"
   #
   #   for scope, delim in delimsByScope
   #     tokens = grammar.tokenizeLines(
@@ -292,15 +292,15 @@ describe "Python3 grammar", ->
   #       + delim
   #     )
   #
-  #     expect(tokens[0][0]).toEqual value: delim, scopes: ['source.python3', scope, 'punctuation.definition.string.begin.python3']
-  #     expect(tokens[1][0]).toEqual value: 'SELECT bar', scopes: ['source.python3', scope]
-  #     expect(tokens[2][0]).toEqual value: 'FROM foo', scopes: ['source.python3', scope]
-  #     expect(tokens[3][0]).toEqual value: delim, scopes: ['source.python3', scope, 'punctuation.definition.string.end.python3']
+  #     expect(tokens[0][0]).toEqual value: delim, scopes: ['source.python.3', scope, 'punctuation.definition.string.begin.python.3']
+  #     expect(tokens[1][0]).toEqual value: 'SELECT bar', scopes: ['source.python.3', scope]
+  #     expect(tokens[2][0]).toEqual value: 'FROM foo', scopes: ['source.python.3', scope]
+  #     expect(tokens[3][0]).toEqual value: delim, scopes: ['source.python.3', scope, 'punctuation.definition.string.end.python.3']
   #
   # it "tokenizes SQL inline highlighting on blocks with a CTE", ->
   #   delimsByScope =
-  #     "string.quoted.double.block.sql.python3": '"""'
-  #     "string.quoted.single.block.sql.python3": "'''"
+  #     "string.quoted.double.block.sql.python.3": '"""'
+  #     "string.quoted.single.block.sql.python.3": "'''"
   #
   #   for scope, delim of delimsByScope
   #     tokens = grammar.tokenizeLines("""
@@ -316,21 +316,21 @@ describe "Python3 grammar", ->
   #       #{delim}
   #     """)
   #
-  #     expect(tokens[0][0]).toEqual value: delim, scopes: ['source.python3', scope, 'punctuation.definition.string.begin.python3']
-  #     expect(tokens[1][0]).toEqual value: 'WITH example_cte AS (', scopes: ['source.python3', scope]
-  #     expect(tokens[2][0]).toEqual value: 'SELECT bar', scopes: ['source.python3', scope]
-  #     expect(tokens[3][0]).toEqual value: 'FROM foo', scopes: ['source.python3', scope]
-  #     expect(tokens[4][0]).toEqual value: 'GROUP BY bar', scopes: ['source.python3', scope]
-  #     expect(tokens[5][0]).toEqual value: ')', scopes: ['source.python3', scope]
-  #     expect(tokens[6][0]).toEqual value: '', scopes: ['source.python3', scope]
-  #     expect(tokens[7][0]).toEqual value: 'SELECT COUNT(*)', scopes: ['source.python3', scope]
-  #     expect(tokens[8][0]).toEqual value: 'FROM example_cte', scopes: ['source.python3', scope]
-  #     expect(tokens[9][0]).toEqual value: delim, scopes: ['source.python3', scope, 'punctuation.definition.string.end.python3']
+  #     expect(tokens[0][0]).toEqual value: delim, scopes: ['source.python.3', scope, 'punctuation.definition.string.begin.python.3']
+  #     expect(tokens[1][0]).toEqual value: 'WITH example_cte AS (', scopes: ['source.python.3', scope]
+  #     expect(tokens[2][0]).toEqual value: 'SELECT bar', scopes: ['source.python.3', scope]
+  #     expect(tokens[3][0]).toEqual value: 'FROM foo', scopes: ['source.python.3', scope]
+  #     expect(tokens[4][0]).toEqual value: 'GROUP BY bar', scopes: ['source.python.3', scope]
+  #     expect(tokens[5][0]).toEqual value: ')', scopes: ['source.python.3', scope]
+  #     expect(tokens[6][0]).toEqual value: '', scopes: ['source.python.3', scope]
+  #     expect(tokens[7][0]).toEqual value: 'SELECT COUNT(*)', scopes: ['source.python.3', scope]
+  #     expect(tokens[8][0]).toEqual value: 'FROM example_cte', scopes: ['source.python.3', scope]
+  #     expect(tokens[9][0]).toEqual value: delim, scopes: ['source.python.3', scope, 'punctuation.definition.string.end.python.3']
   #
   # it "tokenizes SQL inline highlighting on single line with a CTE", ->
   #
   #   {tokens} = grammar.tokenizeLine('\'WITH example_cte AS (SELECT bar FROM foo) SELECT COUNT(*) FROM example_cte\'')
   #
-  #   expect(tokens[0]).toEqual value: '\'', scopes: ['source.python3', 'string.quoted.single.single-line.python3', 'punctuation.definition.string.begin.python3']
-  #   expect(tokens[1]).toEqual value: 'WITH example_cte AS (SELECT bar FROM foo) SELECT COUNT(*) FROM example_cte', scopes: ['source.python3', 'string.quoted.single.single-line.python3']
-  #   expect(tokens[2]).toEqual value: '\'', scopes: ['source.python3', 'string.quoted.single.single-line.python3', 'punctuation.definition.string.end.python3']
+  #   expect(tokens[0]).toEqual value: '\'', scopes: ['source.python.3', 'string.quoted.single.single-line.python.3', 'punctuation.definition.string.begin.python.3']
+  #   expect(tokens[1]).toEqual value: 'WITH example_cte AS (SELECT bar FROM foo) SELECT COUNT(*) FROM example_cte', scopes: ['source.python.3', 'string.quoted.single.single-line.python.3']
+  #   expect(tokens[2]).toEqual value: '\'', scopes: ['source.python.3', 'string.quoted.single.single-line.python.3', 'punctuation.definition.string.end.python.3']

--- a/spec/python3-spec.coffee
+++ b/spec/python3-spec.coffee
@@ -1,0 +1,336 @@
+describe "Python3 grammar", ->
+  grammar = null
+
+  beforeEach ->
+    waitsForPromise ->
+      atom.packages.activatePackage("language-python")
+
+    runs ->
+      grammar = atom.grammars.grammarForScopeName("source.python3")
+
+  it "parses the grammar", ->
+    expect(grammar).toBeDefined()
+    expect(grammar.scopeName).toBe "source.python3"
+
+  it "tokenizes multi-line strings", ->
+    tokens = grammar.tokenizeLines('"1\\\n2"')
+
+    # Line 0
+    expect(tokens[0][0].value).toBe '"'
+    expect(tokens[0][0].scopes).toEqual ['source.python3', 'string.quoted.double.single-line.unicode.python3', 'punctuation.definition.string.begin.python3']
+
+    expect(tokens[0][1].value).toBe '1'
+    expect(tokens[0][1].scopes).toEqual ['source.python3', 'string.quoted.double.single-line.unicode.python3']
+
+    expect(tokens[0][2].value).toBe '\\'
+    expect(tokens[0][2].scopes).toEqual ['source.python3', 'string.quoted.double.single-line.unicode.python3', 'constant.character.escape.newline.python3']
+
+    expect(tokens[0][3]).not.toBeDefined()
+
+    # Line 1
+    expect(tokens[1][0].value).toBe '2'
+    expect(tokens[1][0].scopes).toEqual ['source.python3', 'string.quoted.double.single-line.unicode.python3']
+
+    expect(tokens[1][1].value).toBe '"'
+    expect(tokens[1][1].scopes).toEqual ['source.python3', 'string.quoted.double.single-line.unicode.python3', 'punctuation.definition.string.end.python3']
+
+    expect(tokens[1][2]).not.toBeDefined()
+
+  it "terminates a single-quoted raw string containing opening parenthesis at closing quote", ->
+    tokens = grammar.tokenizeLines("r'%d(' #foo")
+
+    expect(tokens[0][0].value).toBe 'r'
+    expect(tokens[0][0].scopes).toEqual ['source.python3', 'string.quoted.single.single-line.raw-unicode.python3', 'storage.type.string.python3']
+    expect(tokens[0][1].value).toBe "'"
+    expect(tokens[0][1].scopes).toEqual ['source.python3', 'string.quoted.single.single-line.raw-unicode.python3', 'punctuation.definition.string.begin.python3']
+    expect(tokens[0][2].value).toBe '%d'
+    expect(tokens[0][2].scopes).toEqual ['source.python3', 'string.quoted.single.single-line.raw-unicode.python3', 'constant.other.placeholder.printf.python3']
+    expect(tokens[0][3].value).toBe '('
+    expect(tokens[0][3].scopes).toEqual ['source.python3', 'string.quoted.single.single-line.raw-unicode.python3', 'meta.group.regexp', 'punctuation.definition.group.regexp']
+    expect(tokens[0][4].value).toBe "'"
+    expect(tokens[0][4].scopes).toEqual ['source.python3', 'string.quoted.single.single-line.raw-unicode.python3', 'punctuation.definition.string.end.python3']
+    expect(tokens[0][5].value).toBe ' '
+    expect(tokens[0][5].scopes).toEqual ['source.python3']
+    expect(tokens[0][6].value).toBe '#'
+    expect(tokens[0][6].scopes).toEqual ['source.python3', 'comment.line.number-sign.python3', 'punctuation.definition.comment.python3']
+    expect(tokens[0][7].value).toBe 'foo'
+    expect(tokens[0][7].scopes).toEqual ['source.python3', 'comment.line.number-sign.python3']
+
+  it "terminates a single-quoted raw string containing opening bracket at closing quote", ->
+    tokens = grammar.tokenizeLines("r'%d[' #foo")
+
+    expect(tokens[0][0].value).toBe 'r'
+    expect(tokens[0][0].scopes).toEqual ['source.python3', 'string.quoted.single.single-line.raw-unicode.python3', 'storage.type.string.python3']
+    expect(tokens[0][1].value).toBe "'"
+    expect(tokens[0][1].scopes).toEqual ['source.python3', 'string.quoted.single.single-line.raw-unicode.python3', 'punctuation.definition.string.begin.python3']
+    expect(tokens[0][2].value).toBe '%d'
+    expect(tokens[0][2].scopes).toEqual ['source.python3', 'string.quoted.single.single-line.raw-unicode.python3', 'constant.other.placeholder.printf.python3']
+    expect(tokens[0][3].value).toBe '['
+    expect(tokens[0][3].scopes).toEqual ['source.python3', 'string.quoted.single.single-line.raw-unicode.python3', 'constant.other.character-class.set.regexp', 'punctuation.definition.character-class.regexp']
+    expect(tokens[0][4].value).toBe "'"
+    expect(tokens[0][4].scopes).toEqual ['source.python3', 'string.quoted.single.single-line.raw-unicode.python3', 'punctuation.definition.string.end.python3']
+    expect(tokens[0][5].value).toBe ' '
+    expect(tokens[0][5].scopes).toEqual ['source.python3']
+    expect(tokens[0][6].value).toBe '#'
+    expect(tokens[0][6].scopes).toEqual ['source.python3', 'comment.line.number-sign.python3', 'punctuation.definition.comment.python3']
+    expect(tokens[0][7].value).toBe 'foo'
+    expect(tokens[0][7].scopes).toEqual ['source.python3', 'comment.line.number-sign.python3']
+
+  it "terminates a double-quoted raw string containing opening parenthesis at closing quote", ->
+    tokens = grammar.tokenizeLines('r"%d(" #foo')
+
+    expect(tokens[0][0].value).toBe 'r'
+    expect(tokens[0][0].scopes).toEqual ['source.python3', 'string.quoted.double.single-line.raw-unicode.python3', 'storage.type.string.python3']
+    expect(tokens[0][1].value).toBe '"'
+    expect(tokens[0][1].scopes).toEqual ['source.python3', 'string.quoted.double.single-line.raw-unicode.python3', 'punctuation.definition.string.begin.python3']
+    expect(tokens[0][2].value).toBe '%d'
+    expect(tokens[0][2].scopes).toEqual ['source.python3', 'string.quoted.double.single-line.raw-unicode.python3', 'constant.other.placeholder.printf.python3']
+    expect(tokens[0][3].value).toBe '('
+    expect(tokens[0][3].scopes).toEqual ['source.python3', 'string.quoted.double.single-line.raw-unicode.python3', 'meta.group.regexp', 'punctuation.definition.group.regexp']
+    expect(tokens[0][4].value).toBe '"'
+    expect(tokens[0][4].scopes).toEqual ['source.python3', 'string.quoted.double.single-line.raw-unicode.python3', 'punctuation.definition.string.end.python3']
+    expect(tokens[0][5].value).toBe ' '
+    expect(tokens[0][5].scopes).toEqual ['source.python3']
+    expect(tokens[0][6].value).toBe '#'
+    expect(tokens[0][6].scopes).toEqual ['source.python3', 'comment.line.number-sign.python3', 'punctuation.definition.comment.python3']
+    expect(tokens[0][7].value).toBe 'foo'
+    expect(tokens[0][7].scopes).toEqual ['source.python3', 'comment.line.number-sign.python3']
+
+  it "terminates a double-quoted raw string containing opening bracket at closing quote", ->
+    tokens = grammar.tokenizeLines('r"%d[" #foo')
+
+    expect(tokens[0][0].value).toBe 'r'
+    expect(tokens[0][0].scopes).toEqual ['source.python3', 'string.quoted.double.single-line.raw-unicode.python3', 'storage.type.string.python3']
+    expect(tokens[0][1].value).toBe '"'
+    expect(tokens[0][1].scopes).toEqual ['source.python3', 'string.quoted.double.single-line.raw-unicode.python3', 'punctuation.definition.string.begin.python3']
+    expect(tokens[0][2].value).toBe '%d'
+    expect(tokens[0][2].scopes).toEqual ['source.python3', 'string.quoted.double.single-line.raw-unicode.python3', 'constant.other.placeholder.printf.python3']
+    expect(tokens[0][3].value).toBe '['
+    expect(tokens[0][3].scopes).toEqual ['source.python3', 'string.quoted.double.single-line.raw-unicode.python3', 'constant.other.character-class.set.regexp', 'punctuation.definition.character-class.regexp']
+    expect(tokens[0][4].value).toBe '"'
+    expect(tokens[0][4].scopes).toEqual ['source.python3', 'string.quoted.double.single-line.raw-unicode.python3', 'punctuation.definition.string.end.python3']
+    expect(tokens[0][5].value).toBe ' '
+    expect(tokens[0][5].scopes).toEqual ['source.python3']
+    expect(tokens[0][6].value).toBe '#'
+    expect(tokens[0][6].scopes).toEqual ['source.python3', 'comment.line.number-sign.python3', 'punctuation.definition.comment.python3']
+    expect(tokens[0][7].value).toBe 'foo'
+    expect(tokens[0][7].scopes).toEqual ['source.python3', 'comment.line.number-sign.python3']
+
+  it "terminates a bytes single-quoted raw string containing opening parenthesis at closing quote", ->
+    tokens = grammar.tokenizeLines("br'%d(' #foo")
+
+    expect(tokens[0][0].value).toBe 'br'
+    expect(tokens[0][0].scopes).toEqual ['source.python3', 'string.quoted.single.single-line.raw-bytes.python3', 'storage.type.string.python3']
+    expect(tokens[0][1].value).toBe "'"
+    expect(tokens[0][1].scopes).toEqual ['source.python3', 'string.quoted.single.single-line.raw-bytes.python3', 'punctuation.definition.string.begin.python3']
+    expect(tokens[0][2].value).toBe '%d'
+    expect(tokens[0][2].scopes).toEqual ['source.python3', 'string.quoted.single.single-line.raw-bytes.python3', 'constant.other.placeholder.printf.python3']
+    expect(tokens[0][3].value).toBe '('
+    expect(tokens[0][3].scopes).toEqual ['source.python3', 'string.quoted.single.single-line.raw-bytes.python3', 'meta.group.regexp', 'punctuation.definition.group.regexp']
+    expect(tokens[0][4].value).toBe "'"
+    expect(tokens[0][4].scopes).toEqual ['source.python3', 'string.quoted.single.single-line.raw-bytes.python3', 'punctuation.definition.string.end.python3']
+    expect(tokens[0][5].value).toBe ' '
+    expect(tokens[0][5].scopes).toEqual ['source.python3']
+    expect(tokens[0][6].value).toBe '#'
+    expect(tokens[0][6].scopes).toEqual ['source.python3', 'comment.line.number-sign.python3', 'punctuation.definition.comment.python3']
+    expect(tokens[0][7].value).toBe 'foo'
+    expect(tokens[0][7].scopes).toEqual ['source.python3', 'comment.line.number-sign.python3']
+
+  it "terminates a bytes single-quoted raw string containing opening bracket at closing quote", ->
+    tokens = grammar.tokenizeLines("br'%d[' #foo")
+
+    expect(tokens[0][0].value).toBe 'br'
+    expect(tokens[0][0].scopes).toEqual ['source.python3', 'string.quoted.single.single-line.raw-bytes.python3', 'storage.type.string.python3']
+    expect(tokens[0][1].value).toBe "'"
+    expect(tokens[0][1].scopes).toEqual ['source.python3', 'string.quoted.single.single-line.raw-bytes.python3', 'punctuation.definition.string.begin.python3']
+    expect(tokens[0][2].value).toBe '%d'
+    expect(tokens[0][2].scopes).toEqual ['source.python3', 'string.quoted.single.single-line.raw-bytes.python3', 'constant.other.placeholder.printf.python3']
+    expect(tokens[0][3].value).toBe '['
+    expect(tokens[0][3].scopes).toEqual ['source.python3', 'string.quoted.single.single-line.raw-bytes.python3', 'constant.other.character-class.set.regexp', 'punctuation.definition.character-class.regexp']
+    expect(tokens[0][4].value).toBe "'"
+    expect(tokens[0][4].scopes).toEqual ['source.python3', 'string.quoted.single.single-line.raw-bytes.python3', 'punctuation.definition.string.end.python3']
+    expect(tokens[0][5].value).toBe ' '
+    expect(tokens[0][5].scopes).toEqual ['source.python3']
+    expect(tokens[0][6].value).toBe '#'
+    expect(tokens[0][6].scopes).toEqual ['source.python3', 'comment.line.number-sign.python3', 'punctuation.definition.comment.python3']
+    expect(tokens[0][7].value).toBe 'foo'
+    expect(tokens[0][7].scopes).toEqual ['source.python3', 'comment.line.number-sign.python3']
+
+  it "terminates a bytes double-quoted raw string containing opening parenthesis at closing quote", ->
+    tokens = grammar.tokenizeLines('br"%d(" #foo')
+
+    expect(tokens[0][0].value).toBe 'br'
+    expect(tokens[0][0].scopes).toEqual ['source.python3', 'string.quoted.double.single-line.raw-bytes.python3', 'storage.type.string.python3']
+    expect(tokens[0][1].value).toBe '"'
+    expect(tokens[0][1].scopes).toEqual ['source.python3', 'string.quoted.double.single-line.raw-bytes.python3', 'punctuation.definition.string.begin.python3']
+    expect(tokens[0][2].value).toBe '%d'
+    expect(tokens[0][2].scopes).toEqual ['source.python3', 'string.quoted.double.single-line.raw-bytes.python3', 'constant.other.placeholder.printf.python3']
+    expect(tokens[0][3].value).toBe '('
+    expect(tokens[0][3].scopes).toEqual ['source.python3', 'string.quoted.double.single-line.raw-bytes.python3', 'meta.group.regexp', 'punctuation.definition.group.regexp']
+    expect(tokens[0][4].value).toBe '"'
+    expect(tokens[0][4].scopes).toEqual ['source.python3', 'string.quoted.double.single-line.raw-bytes.python3', 'punctuation.definition.string.end.python3']
+    expect(tokens[0][5].value).toBe ' '
+    expect(tokens[0][5].scopes).toEqual ['source.python3']
+    expect(tokens[0][6].value).toBe '#'
+    expect(tokens[0][6].scopes).toEqual ['source.python3', 'comment.line.number-sign.python3', 'punctuation.definition.comment.python3']
+    expect(tokens[0][7].value).toBe 'foo'
+    expect(tokens[0][7].scopes).toEqual ['source.python3', 'comment.line.number-sign.python3']
+
+  it "terminates a bytes double-quoted raw string containing opening bracket at closing quote", ->
+    tokens = grammar.tokenizeLines('br"%d[" #foo')
+
+    expect(tokens[0][0].value).toBe 'br'
+    expect(tokens[0][0].scopes).toEqual ['source.python3', 'string.quoted.double.single-line.raw-bytes.python3', 'storage.type.string.python3']
+    expect(tokens[0][1].value).toBe '"'
+    expect(tokens[0][1].scopes).toEqual ['source.python3', 'string.quoted.double.single-line.raw-bytes.python3', 'punctuation.definition.string.begin.python3']
+    expect(tokens[0][2].value).toBe '%d'
+    expect(tokens[0][2].scopes).toEqual ['source.python3', 'string.quoted.double.single-line.raw-bytes.python3', 'constant.other.placeholder.printf.python3']
+    expect(tokens[0][3].value).toBe '['
+    expect(tokens[0][3].scopes).toEqual ['source.python3', 'string.quoted.double.single-line.raw-bytes.python3', 'constant.other.character-class.set.regexp', 'punctuation.definition.character-class.regexp']
+    expect(tokens[0][4].value).toBe '"'
+    expect(tokens[0][4].scopes).toEqual ['source.python3', 'string.quoted.double.single-line.raw-bytes.python3', 'punctuation.definition.string.end.python3']
+    expect(tokens[0][5].value).toBe ' '
+    expect(tokens[0][5].scopes).toEqual ['source.python3']
+    expect(tokens[0][6].value).toBe '#'
+    expect(tokens[0][6].scopes).toEqual ['source.python3', 'comment.line.number-sign.python3', 'punctuation.definition.comment.python3']
+    expect(tokens[0][7].value).toBe 'foo'
+    expect(tokens[0][7].scopes).toEqual ['source.python3', 'comment.line.number-sign.python3']
+
+  it "terminates referencing an item in a list variable after a sequence of a closing and opening bracket", ->
+    tokens = grammar.tokenizeLines('foo[i[0]][j[0]]')
+
+    expect(tokens[0][0].value).toBe 'foo'
+    expect(tokens[0][0].scopes).toEqual ['source.python3', 'meta.item-access.python3']
+    expect(tokens[0][1].value).toBe '['
+    expect(tokens[0][1].scopes).toEqual ['source.python3', 'meta.item-access.python3', 'punctuation.definition.arguments.begin.python3']
+    expect(tokens[0][2].value).toBe 'i'
+    expect(tokens[0][2].scopes).toEqual ['source.python3', 'meta.item-access.python3', 'meta.item-access.arguments.python3', 'meta.item-access.python3']
+    expect(tokens[0][3].value).toBe '['
+    expect(tokens[0][3].scopes).toEqual ['source.python3', 'meta.item-access.python3', 'meta.item-access.arguments.python3', 'meta.item-access.python3', 'punctuation.definition.arguments.begin.python3']
+    expect(tokens[0][4].value).toBe '0'
+    expect(tokens[0][4].scopes).toEqual ['source.python3', 'meta.item-access.python3', 'meta.item-access.arguments.python3', 'meta.item-access.python3', 'meta.item-access.arguments.python3', 'constant.numeric.integer.decimal.python3']
+    expect(tokens[0][5].value).toBe ']'
+    expect(tokens[0][5].scopes).toEqual ['source.python3', 'meta.item-access.python3', 'meta.item-access.arguments.python3', 'meta.item-access.python3', 'punctuation.definition.arguments.end.python3']
+    expect(tokens[0][6].value).toBe ']'
+    expect(tokens[0][6].scopes).toEqual ['source.python3', 'meta.item-access.python3', 'punctuation.definition.arguments.end.python3']
+    expect(tokens[0][7].value).toBe '['
+    expect(tokens[0][7].scopes).toEqual ['source.python3', 'meta.structure.list.python3', 'punctuation.definition.list.begin.python3']
+    expect(tokens[0][8].value).toBe 'j'
+    expect(tokens[0][8].scopes).toEqual ['source.python3', 'meta.structure.list.python3', 'meta.structure.list.item.python3', 'meta.item-access.python3']
+    expect(tokens[0][9].value).toBe '['
+    expect(tokens[0][9].scopes).toEqual ['source.python3', 'meta.structure.list.python3', 'meta.structure.list.item.python3', 'meta.item-access.python3', 'punctuation.definition.arguments.begin.python3']
+    expect(tokens[0][10].value).toBe '0'
+    expect(tokens[0][10].scopes).toEqual ['source.python3', 'meta.structure.list.python3', 'meta.structure.list.item.python3', 'meta.item-access.python3', 'meta.item-access.arguments.python3', 'constant.numeric.integer.decimal.python3']
+    expect(tokens[0][11].value).toBe ']'
+    expect(tokens[0][11].scopes).toEqual ['source.python3', 'meta.structure.list.python3', 'meta.structure.list.item.python3', 'meta.item-access.python3', 'punctuation.definition.arguments.end.python3']
+    expect(tokens[0][12].value).toBe ']'
+    expect(tokens[0][12].scopes).toEqual ['source.python3', 'meta.structure.list.python3', 'punctuation.definition.list.end.python3']
+
+  it "tokenizes properties of self as variables", ->
+    tokens = grammar.tokenizeLines('self.foo')
+
+    expect(tokens[0][0].value).toBe 'self'
+    expect(tokens[0][0].scopes).toEqual ['source.python3', 'variable.language.python3']
+    expect(tokens[0][1].value).toBe '.'
+    expect(tokens[0][1].scopes).toEqual ['source.python3']
+    expect(tokens[0][2].value).toBe 'foo'
+    expect(tokens[0][2].scopes).toEqual ['source.python3']
+
+  it "tokenizes properties of a variable as variables", ->
+    tokens = grammar.tokenizeLines('bar.foo')
+
+    expect(tokens[0][0].value).toBe 'bar'
+    expect(tokens[0][0].scopes).toEqual ['source.python3']
+    expect(tokens[0][1].value).toBe '.'
+    expect(tokens[0][1].scopes).toEqual ['source.python3']
+    expect(tokens[0][2].value).toBe 'foo'
+    expect(tokens[0][2].scopes).toEqual ['source.python3']
+
+  it "tokenizes comments inside function parameters", ->
+    {tokens} = grammar.tokenizeLine('def test(arg, # comment')
+
+    expect(tokens[0]).toEqual value: 'def', scopes: ['source.python3', 'meta.function.python3', 'storage.type.function.python3']
+    expect(tokens[2]).toEqual value: 'test', scopes: ['source.python3', 'meta.function.python3', 'entity.name.function.python3']
+    expect(tokens[3]).toEqual value: '(', scopes: ['source.python3', 'meta.function.python3', 'punctuation.definition.parameters.begin.python3']
+    expect(tokens[4]).toEqual value: 'arg', scopes: ['source.python3', 'meta.function.python3', 'meta.function.parameters.python3', 'variable.parameter.function.python3']
+    expect(tokens[5]).toEqual value: ',', scopes: ['source.python3', 'meta.function.python3', 'meta.function.parameters.python3', 'punctuation.separator.parameters.python3']
+    expect(tokens[7]).toEqual value: '#', scopes: ['source.python3', 'meta.function.python3', 'meta.function.parameters.python3', 'comment.line.number-sign.python3', 'punctuation.definition.comment.python3']
+    expect(tokens[8]).toEqual value: ' comment', scopes: ['source.python3', 'meta.function.python3', 'meta.function.parameters.python3', 'comment.line.number-sign.python3']
+
+    tokens = grammar.tokenizeLines("""
+      def __init__(
+        self,
+        codec, # comment
+        config
+      ):
+    """)
+
+    expect(tokens[0][0]).toEqual value: 'def', scopes: ['source.python3', 'meta.function.python3', 'storage.type.function.python3']
+    expect(tokens[0][2]).toEqual value: '__init__', scopes: ['source.python3', 'meta.function.python3', 'entity.name.function.python3', 'support.function.magic.python3']
+    expect(tokens[0][3]).toEqual value: '(', scopes: ['source.python3', 'meta.function.python3', 'punctuation.definition.parameters.begin.python3']
+    expect(tokens[1][1]).toEqual value: 'self', scopes: ['source.python3', 'meta.function.python3', 'meta.function.parameters.python3', 'variable.parameter.function.python3']
+    expect(tokens[1][2]).toEqual value: ',', scopes: ['source.python3', 'meta.function.python3', 'meta.function.parameters.python3', 'punctuation.separator.parameters.python3']
+    expect(tokens[2][1]).toEqual value: 'codec', scopes: ['source.python3', 'meta.function.python3', 'meta.function.parameters.python3', 'variable.parameter.function.python3']
+    expect(tokens[2][2]).toEqual value: ',', scopes: ['source.python3', 'meta.function.python3', 'meta.function.parameters.python3', 'punctuation.separator.parameters.python3']
+    expect(tokens[2][4]).toEqual value: '#', scopes: ['source.python3', 'meta.function.python3', 'meta.function.parameters.python3', 'comment.line.number-sign.python3', 'punctuation.definition.comment.python3']
+    expect(tokens[2][5]).toEqual value: ' comment', scopes: ['source.python3', 'meta.function.python3', 'meta.function.parameters.python3', 'comment.line.number-sign.python3']
+    expect(tokens[3][1]).toEqual value: 'config', scopes: ['source.python3', 'meta.function.python3', 'meta.function.parameters.python3', 'variable.parameter.function.python3']
+    expect(tokens[4][0]).toEqual value: ')', scopes: ['source.python3', 'meta.function.python3', 'punctuation.definition.parameters.end.python3']
+    expect(tokens[4][1]).toEqual value: ':', scopes: ['source.python3', 'meta.function.python3', 'punctuation.section.function.begin.python3']
+
+
+  # it "tokenizes SQL inline highlighting on blocks", ->
+  #   delimsByScope =
+  #     "string.quoted.double.block.sql.python3": '"""'
+  #     "string.quoted.single.block.sql.python3": "'''"
+  #
+  #   for scope, delim in delimsByScope
+  #     tokens = grammar.tokenizeLines(
+  #       delim +
+  #       'SELECT bar
+  #       FROM foo'
+  #       + delim
+  #     )
+  #
+  #     expect(tokens[0][0]).toEqual value: delim, scopes: ['source.python3', scope, 'punctuation.definition.string.begin.python3']
+  #     expect(tokens[1][0]).toEqual value: 'SELECT bar', scopes: ['source.python3', scope]
+  #     expect(tokens[2][0]).toEqual value: 'FROM foo', scopes: ['source.python3', scope]
+  #     expect(tokens[3][0]).toEqual value: delim, scopes: ['source.python3', scope, 'punctuation.definition.string.end.python3']
+  #
+  # it "tokenizes SQL inline highlighting on blocks with a CTE", ->
+  #   delimsByScope =
+  #     "string.quoted.double.block.sql.python3": '"""'
+  #     "string.quoted.single.block.sql.python3": "'''"
+  #
+  #   for scope, delim of delimsByScope
+  #     tokens = grammar.tokenizeLines("""
+  #       #{delim}
+  #       WITH example_cte AS (
+  #       SELECT bar
+  #       FROM foo
+  #       GROUP BY bar
+  #       )
+  #
+  #       SELECT COUNT(*)
+  #       FROM example_cte
+  #       #{delim}
+  #     """)
+  #
+  #     expect(tokens[0][0]).toEqual value: delim, scopes: ['source.python3', scope, 'punctuation.definition.string.begin.python3']
+  #     expect(tokens[1][0]).toEqual value: 'WITH example_cte AS (', scopes: ['source.python3', scope]
+  #     expect(tokens[2][0]).toEqual value: 'SELECT bar', scopes: ['source.python3', scope]
+  #     expect(tokens[3][0]).toEqual value: 'FROM foo', scopes: ['source.python3', scope]
+  #     expect(tokens[4][0]).toEqual value: 'GROUP BY bar', scopes: ['source.python3', scope]
+  #     expect(tokens[5][0]).toEqual value: ')', scopes: ['source.python3', scope]
+  #     expect(tokens[6][0]).toEqual value: '', scopes: ['source.python3', scope]
+  #     expect(tokens[7][0]).toEqual value: 'SELECT COUNT(*)', scopes: ['source.python3', scope]
+  #     expect(tokens[8][0]).toEqual value: 'FROM example_cte', scopes: ['source.python3', scope]
+  #     expect(tokens[9][0]).toEqual value: delim, scopes: ['source.python3', scope, 'punctuation.definition.string.end.python3']
+  #
+  # it "tokenizes SQL inline highlighting on single line with a CTE", ->
+  #
+  #   {tokens} = grammar.tokenizeLine('\'WITH example_cte AS (SELECT bar FROM foo) SELECT COUNT(*) FROM example_cte\'')
+  #
+  #   expect(tokens[0]).toEqual value: '\'', scopes: ['source.python3', 'string.quoted.single.single-line.python3', 'punctuation.definition.string.begin.python3']
+  #   expect(tokens[1]).toEqual value: 'WITH example_cte AS (SELECT bar FROM foo) SELECT COUNT(*) FROM example_cte', scopes: ['source.python3', 'string.quoted.single.single-line.python3']
+  #   expect(tokens[2]).toEqual value: '\'', scopes: ['source.python3', 'string.quoted.single.single-line.python3', 'punctuation.definition.string.end.python3']


### PR DESCRIPTION
Adds Python3 as a separate grammar. This grammar scope is 'source.python.3' in order to be recognized by all other tools as a Python grammar.

This Grammar is based on Python 3.5.1
# Features
- **Support for all string prefixes:** _u_ or no prefix for unicode strings, _r_ for raw unicode strings, _b_ for   bytes string, and _rb_ or _br_ for raw bytes strings.
- New async and await keywords. async is defined as a 'storage.modifier.coroutine'.
- Revamped builtin functions and exceptions.
# Exemple:

![language-python-pic](https://cloud.githubusercontent.com/assets/495025/11846915/217b4f86-a41b-11e5-870b-35125896d907.png)

_PS: Sorry for the double pull, some lines on the specs verification script have to be changed_
