### PR TITLE
No newline after pdb/ipdb for consistency with other mid-file snippets

### DIFF
--- a/snippets/language-python.cson
+++ b/snippets/language-python.cson
@@ -88,10 +88,10 @@
     'body': '{${1:key}: ${2:value} for ${3:key}, ${4:value} in ${5:variable}}'
   'PDB set trace':
     'prefix': 'pdb'
-    'body': 'import pdb; pdb.set_trace()\n'
+    'body': 'import pdb; pdb.set_trace()'
   'iPDB set trace':
     'prefix': 'ipdb'
-    'body': 'import ipdb; ipdb.set_trace()\n'
+    'body': 'import ipdb; ipdb.set_trace()'
   '__magic__':
     'prefix': '__'
     'body': '__${1:init}__'


### PR DESCRIPTION
If you use the pdb/ipdb snippet, an extra newline is inserted into your code. This is undesirable, and inconsistent with all other snippets (with the exception of enc/env, where it makes sense).

This PR removes the extra newlines.