### PR TITLE
Inline blocks such as "else : expr" will only dedent once

### DIFF
--- a/settings/language-python.cson
+++ b/settings/language-python.cson
@@ -6,4 +6,4 @@
     'foldEndPattern': '^\\s*"""\\s*$'
     'commentStart': '# '
     'increaseIndentPattern': '^\\s*(class|def|elif|else|except|finally|for|if|try|with|while)\\b.*:\\s*$'
-    'decreaseIndentPattern': '^\\s*(elif|else|except|finally)\\b.*:'
+    'decreaseIndentPattern': '^\\s*(elif|else|except|finally)\\b.*:\\s*$'


### PR DESCRIPTION
Unfortunately, when you finish typing "else :" it will match the regex and
dedent, but it will not keep dedenting once you've started typing the
expression.

See [atom/atom/issues/10973](https://github.com/atom/atom/issues/10973)

**_NOTE:**_
There were no specs testing the indentation at all for me to copy, and I do not know enough about the framework to write them myself from scratch. I would appreciate some pointers on that.
