### PR TITLE
Fixing the class snippet by adding period to the doc string

### DIFF
--- a/snippets/language-python.cson
+++ b/snippets/language-python.cson
@@ -46,7 +46,7 @@
     'body': 'self.fail(\'${1:message}\')$0'
   'New Class':
     'prefix': 'class'
-    'body': 'class ${1:ClassName}(${2:object}):\n\t"""${3:docstring for $1}"""\n\tdef __init__(self, ${4:arg}):\n\t\t${5:super($1, self).__init__()}\n\t\tself.arg = arg\n\t\t$0'
+    'body': 'class ${1:ClassName}(${2:object}):\n\t"""${3:docstring for $1.}"""\n\tdef __init__(self, ${4:arg}):\n\t\t${5:super($1, self).__init__()}\n\t\tself.arg = arg\n\t\t$0'
   'New Method':
     'prefix': 'defs'
     'body': 'def ${1:mname}(self, ${2:arg}):\n\t${3:pass}'


### PR DESCRIPTION
The python [PEP 257 states](https://www.python.org/dev/peps/pep-0257/) that for one line doc strings:

> "The docstring is a phrase ending in a period."

This PR is adding a period to the class snippet, so that is complies with PEP 257
