### PR TITLE
Add @property snippet and rename the previous one

### DIFF
--- a/snippets/language-python.cson
+++ b/snippets/language-python.cson
@@ -59,8 +59,11 @@
   'New Function':
     'prefix': 'def'
     'body': 'def ${1:fname}(${2:arg}):\n\t${3:pass}'
-  'New Property':
+  'New Property (decorator)':
     'prefix': 'property'
+    'body': '@property\ndef ${1:prop_name}(self):\n\treturn ${2:"foo"}'
+  'New Property (function)':
+    'prefix': 'propertyf'
     'body': 'def ${1:foo}():\n    doc = "${2:The $1 property.}"\n    def fget(self):\n        ${3:return self._$1}\n    def fset(self, value):\n        ${4:self._$1 = value}\n    def fdel(self):\n        ${5:del self._$1}\n    return locals()\n$1 = property(**$1())$0'
   'if':
     'prefix': 'if'


### PR DESCRIPTION
Thanks for this great plugin!

After using it, I realized I use more often the `@property` decorator more than the full property definition. I believe we could replace the `property` snippet by the decorator one, and leave the other as a second choice. What do you guys think?
