### PR TITLE
Resolving Incorrect indent of inline if's, elif's and else's.

### DIFF
--- a/settings/language-python.cson
+++ b/settings/language-python.cson
@@ -4,5 +4,5 @@
     'softTabs': true
     'tabLength': 4
     'commentStart': '# '
-    'increaseIndentPattern': '^\\s*(class|def|elif|else|except|finally|for|if|try|with|while)\\b.*:.*$'
-    'decreaseIndentPattern': '^\\s*(elif|else|except|finally)\\b.*:'
+    'increaseIndentPattern': '^\\s*(((class|def|elif|except|finally|for|if|try|with|while)\\b.*:.*)|(else\\b.*:\\s*))$'
+    'decreaseIndentPattern': '^\\s*(elif|else|except|finally)\\b.*:\\s*$'

--- a/settings/language-python.cson
+++ b/settings/language-python.cson
@@ -4,5 +4,5 @@
     'softTabs': true
     'tabLength': 4
     'commentStart': '# '
-    'increaseIndentPattern': '^\\s*(class|def|elif|else|except|finally|for|if|try|with|while)\\b.*:\\s*$'
+    'increaseIndentPattern': '^\\s*(class|def|elif|else|except|finally|for|if|try|with|while)\\b.*:.*$'
     'decreaseIndentPattern': '^\\s*(elif|else|except|finally)\\b.*:'


### PR DESCRIPTION
As brought up in #159 when an if statement is inlined e.g. 

``` python
    if conditional: return 5
```

No indent is applied as a result when all subsequent else's and elif's de-indent they will placed in the wrong position for example

``` python
     if conditional: return 5
   elif: return 90
   else: return 10
```

This issue was resolved by forcing an indent on all if's, elif's and non-inlined else's.
