### PR TITLE
add regex to support spaces in firstline shebang, add corresponding specs

### DIFF
--- a/grammars/python.cson
+++ b/grammars/python.cson
@@ -16,7 +16,7 @@
   'tac'
   'wsgi'
 ]
-'firstLineMatch': '^#!/.*\\bpython[\\d\\.]*\\b'
+'firstLineMatch': '^#![ \\t]*/.*\\bpython[\\d\\.]*\\b'
 'patterns': [
   {
     'include': '#line_comments'

--- a/spec/python-spec.coffee
+++ b/spec/python-spec.coffee
@@ -8,6 +8,10 @@ describe "Python grammar", ->
     runs ->
       grammar = atom.grammars.grammarForScopeName("source.python")
 
+  it "recognises shebang on firstline", ->
+    expect(grammar.firstLineRegex.scanner.findNextMatchSync("#!/usr/bin/env python")).not.toBeNull()
+    expect(grammar.firstLineRegex.scanner.findNextMatchSync("#! /usr/bin/env python")).not.toBeNull()
+
   it "parses the grammar", ->
     expect(grammar).toBeDefined()
     expect(grammar.scopeName).toBe "source.python"


### PR DESCRIPTION
### Description of the Change

Added space regex in between she bang and start of path. Fix for #173 

### Alternate Designs

None considered
### Benefits

Better shebang Python language detection.
### Applicable Issues
#173 
