### PR TITLE
Removed tabLength

### DIFF
--- a/settings/language-python.cson
+++ b/settings/language-python.cson
@@ -2,7 +2,6 @@
   'editor':
     'autoIndentOnPaste': false
     'softTabs': true
-    'tabLength': 4
     'commentStart': '# '
     'increaseIndentPattern': '^\\s*(class|def|elif|else|except|finally|for|if|try|with|while)\\b.*:\\s*$'
     'decreaseIndentPattern': '^\\s*(elif|else|except|finally)\\b.*:'


### PR DESCRIPTION
By removing this line python will automatically inherit the indentation. This fixes bugs reported by the community

### Description of the Change

Removed a default setting of the tabLength since this was causing issues with some users who use the tab size as 2. The recommended tab size is 4, however this setting was making it difficult for users to change their tab size, since it doesn't inherit it from the Atom settings but is predefined here. 
By removing this line, Atom will default to using the predefined Unscoped tab length rather than the tab length as 4. 

### Benefits

Users will be able to more effectively set their tab size.

### Possible Drawbacks

Users by default will not have a tab size of 4 for working in Python.

### Applicable Issues

Issues fixed include the issue I and others opened about python using 4 spaces instead of what was defined in the python settings. This was because when you put the tabLength to be the same in the Settings as in the Python Settings, it removes the line from python settings and python defaults back to 4. This patch fixes this bug by defaulting the tab size.
