### PR TITLE
Be compliant with the Python documentation

### DIFF
--- a/snippets/language-python.cson
+++ b/snippets/language-python.cson
@@ -4,7 +4,7 @@
     'body': '#!/usr/bin/env python\n'
   '# coding=utf-8':
     'prefix': 'enc'
-    'body': '# coding=utf-8\n'
+    'body': '# -*- coding: utf-8 -*-\n'
   'Import':
     'prefix': 'im'
     'body': 'import ${1:package/module}'


### PR DESCRIPTION
### Description of the Change

Even if -*- is cosmetic and encoding: utf8 is equal to encoding= utf8 in the Python documentation the shown example is 
```
#!/usr/bin/env python
# -*- coding: latin-1 -*-
```

See:

- https://docs.python.org/3/howto/unicode.html#unicode-literals-in-python-source-code

I would use the form proposed in the doc.

### Benefits

It seems to me that the proposed format is more popular.