### PR TITLE
Add with statement to snippets

### DIFF
--- a/snippets/language-python.cson
+++ b/snippets/language-python.cson
@@ -71,6 +71,9 @@
   'while':
     'prefix': 'while'
     'body': 'while ${1:condition}:\n\t${2:pass}'
+  'with statement':
+    'prefix': 'with'
+    'body': 'with ${1:expression} as ${2:target}:\n\t${3:pass}'
   'Try/Except/Else/Finally':
     'prefix': 'tryef'
     'body': 'try:\n\t${1:pass}\nexcept${2: ${3:Exception} as ${4:e}}:\n\t${5:raise}\nelse:\n\t${6:pass}\nfinally:\n\t${7:pass}'


### PR DESCRIPTION
### Description of the Change

After reviewing a recent reddit discussion about [the most repetitive code pieces people type](https://www.reddit.com/r/Python/comments/6bjgkt/what_are_the_most_repetitive_pieces_of_code_that/), I checked the most often mentioned items against the available snippet list. The only one that stood out to me as missing was the with statement, which I add here after confirming that it works in my own snippets.

It's basically copy/pasted from the for statement snippet, and a simple change, so should hopefully be ok without tests? other snippet PRs were also merged without

### Benefits

Adds a with statement snippet