### PR TITLE
Closes #200 Makes escaped hex include lowercase hex chars

### DIFF
--- a/grammars/python.cson
+++ b/grammars/python.cson
@@ -800,7 +800,7 @@
         'name': 'constant.character.escape.tab.python'
       '13':
         'name': 'constant.character.escape.vertical-tab.python'
-    'match': '(\\\\x[0-9A-F]{2})|(\\\\[0-7]{3})|(\\\\\\n)|(\\\\\\\\)|(\\\\\\")|(\\\\\')|(\\\\a)|(\\\\b)|(\\\\f)|(\\\\n)|(\\\\r)|(\\\\t)|(\\\\v)'
+    'match': '(\\\\x[0-9A-Fa-f]{2})|(\\\\[0-7]{3})|(\\\\\\n)|(\\\\\\\\)|(\\\\\\")|(\\\\\')|(\\\\a)|(\\\\b)|(\\\\f)|(\\\\n)|(\\\\r)|(\\\\t)|(\\\\v)'
   'escaped_unicode_char':
     'captures':
       '1':

--- a/grammars/python.cson
+++ b/grammars/python.cson
@@ -800,7 +800,7 @@
         'name': 'constant.character.escape.tab.python'
       '13':
         'name': 'constant.character.escape.vertical-tab.python'
-    'match': '(\\\\x[0-9A-Fa-f]{2})|(\\\\[0-7]{3})|(\\\\\\n)|(\\\\\\\\)|(\\\\\\")|(\\\\\')|(\\\\a)|(\\\\b)|(\\\\f)|(\\\\n)|(\\\\r)|(\\\\t)|(\\\\v)'
+    'match': '(\\\\x[\\h]{2})|(\\\\[0-7]{3})|(\\\\\\n)|(\\\\\\\\)|(\\\\\\")|(\\\\\')|(\\\\a)|(\\\\b)|(\\\\f)|(\\\\n)|(\\\\r)|(\\\\t)|(\\\\v)'
   'escaped_unicode_char':
     'captures':
       '1':


### PR DESCRIPTION
### Description of the Change

This makes the atom interpreter recognize lowercase hex characters in escaped hex sequences.

### Alternate Designs
None were proposed, this is a simple bug fix. The original developer likely forgot that lowercase hex chars can be used. 

### Benefits

Escaped hex with a lowercase hex character such as "\x4a" will now be recongized as an escaped hex sequence. 

### Possible Drawbacks

None

### Applicable Issues

#200 
