### PR TITLE
Indentation updates

### DIFF
--- a/settings/language-python.cson
+++ b/settings/language-python.cson
@@ -5,5 +5,5 @@
     'tabLength': 4
     'commentStart': '# '
     'increaseIndentPattern': '^\\s*(class|def|elif|else|except|finally|for|if|try|with|while)\\b.*:\\s*$'
-    'decreaseIndentPattern': '^\\s*(elif|else|except|finally)\\b.*:'
+    'decreaseIndentPattern': '^\\s*(elif|else|except|finally)\\b.*:\\s*$'
     'decreaseNextIndentPattern': '^\\s*(return|yield|continue|break|raise)\\b.*$'

--- a/settings/language-python.cson
+++ b/settings/language-python.cson
@@ -6,3 +6,4 @@
     'commentStart': '# '
     'increaseIndentPattern': '^\\s*(class|def|elif|else|except|finally|for|if|try|with|while)\\b.*:\\s*$'
     'decreaseIndentPattern': '^\\s*(elif|else|except|finally)\\b.*:'
+    'decreaseNextIndentPattern': '^\\s*(return|yield|continue|break|raise)\\b.*$'

--- a/settings/language-python.cson
+++ b/settings/language-python.cson
@@ -6,4 +6,4 @@
     'commentStart': '# '
     'increaseIndentPattern': '^\\s*(class|def|elif|else|except|finally|for|if|try|with|while)\\b.*:\\s*$'
     'decreaseIndentPattern': '^\\s*(elif|else|except|finally)\\b.*:\\s*$'
-    'decreaseNextIndentPattern': '^\\s*(return|yield|continue|break|raise)\\b.*$'
+    'decreaseNextIndentPattern': '^\\s*(pass|return|yield|continue|break|raise)\\b.*$'

--- a/spec/language-python-spec.coffee
+++ b/spec/language-python-spec.coffee
@@ -85,5 +85,6 @@ describe 'Python settings', ->
     expect(decreaseNextIndentRegex.testSync('    yield expression()')).toBeTruthy()
     expect(decreaseNextIndentRegex.testSync('    continue')).toBeTruthy()
     expect(decreaseNextIndentRegex.testSync('    break')).toBeTruthy()
+    expect(decreaseNextIndentRegex.testSync('    pass')).toBeTruthy()
     expect(decreaseNextIndentRegex.testSync('    raise')).toBeTruthy()
     expect(decreaseNextIndentRegex.testSync('    raise Exception()')).toBeTruthy()

--- a/spec/language-python-spec.coffee
+++ b/spec/language-python-spec.coffee
@@ -1,0 +1,89 @@
+describe 'Python settings', ->
+  [editor, languageMode] = []
+
+  afterEach ->
+    editor.destroy()
+
+  beforeEach ->
+    waitsForPromise ->
+      atom.workspace.open('sample.py').then (o) ->
+        editor = o
+        languageMode = editor.languageMode
+
+    waitsForPromise ->
+      atom.packages.activatePackage('language-python')
+
+  it 'matches lines correctly using the increaseIndentPattern', ->
+    increaseIndentRegex = languageMode.increaseIndentRegexForScopeDescriptor(['source.python'])
+
+    expect(increaseIndentRegex.testSync('for i in range(n):')).toBeTruthy()
+    expect(increaseIndentRegex.testSync('  for i in range(n):')).toBeTruthy()
+    expect(increaseIndentRegex.testSync('class TheClass(Object):')).toBeTruthy()
+    expect(increaseIndentRegex.testSync('  class TheClass(Object):')).toBeTruthy()
+    expect(increaseIndentRegex.testSync('def f(x):')).toBeTruthy()
+    expect(increaseIndentRegex.testSync('  def f(x):')).toBeTruthy()
+    expect(increaseIndentRegex.testSync('if this_var == that_var:')).toBeTruthy()
+    expect(increaseIndentRegex.testSync('  if this_var == that_var:')).toBeTruthy()
+    expect(increaseIndentRegex.testSync('elif this_var == that_var:')).toBeTruthy()
+    expect(increaseIndentRegex.testSync('  elif this_var == that_var:')).toBeTruthy()
+    expect(increaseIndentRegex.testSync('else:')).toBeTruthy()
+    expect(increaseIndentRegex.testSync('  else:')).toBeTruthy()
+    expect(increaseIndentRegex.testSync('except Exception:')).toBeTruthy()
+    expect(increaseIndentRegex.testSync('  except Exception:')).toBeTruthy()
+    expect(increaseIndentRegex.testSync('except Exception as e:')).toBeTruthy()
+    expect(increaseIndentRegex.testSync('  except Exception as e:')).toBeTruthy()
+    expect(increaseIndentRegex.testSync('finally:')).toBeTruthy()
+    expect(increaseIndentRegex.testSync('  finally:')).toBeTruthy()
+    expect(increaseIndentRegex.testSync('with open("filename") as f:')).toBeTruthy()
+    expect(increaseIndentRegex.testSync('  with open("filename") as f:')).toBeTruthy()
+    expect(increaseIndentRegex.testSync('while True:')).toBeTruthy()
+    expect(increaseIndentRegex.testSync('  while True:')).toBeTruthy()
+    expect(increaseIndentRegex.testSync('\t\t  while True:')).toBeTruthy()
+
+  it 'does not match lines incorrectly using the increaseIndentPattern', ->
+    increaseIndentRegex = languageMode.increaseIndentRegexForScopeDescriptor(['source.python'])
+
+    expect(increaseIndentRegex.testSync('for i in range(n)')).toBeFalsy()
+    expect(increaseIndentRegex.testSync('class TheClass(Object)')).toBeFalsy()
+    expect(increaseIndentRegex.testSync('def f(x)')).toBeFalsy()
+    expect(increaseIndentRegex.testSync('if this_var == that_var')).toBeFalsy()
+    expect(increaseIndentRegex.testSync('"for i in range(n):"')).toBeFalsy()
+
+  it 'matches lines correctly using the decreaseIndentPattern', ->
+    decreaseIndentRegex = languageMode.decreaseIndentRegexForScopeDescriptor(['source.python'])
+
+    expect(decreaseIndentRegex.testSync('elif this_var == that_var:')).toBeTruthy()
+    expect(decreaseIndentRegex.testSync('  elif this_var == that_var:')).toBeTruthy()
+    expect(decreaseIndentRegex.testSync('else:')).toBeTruthy()
+    expect(decreaseIndentRegex.testSync('  else:')).toBeTruthy()
+    expect(decreaseIndentRegex.testSync('except Exception:')).toBeTruthy()
+    expect(decreaseIndentRegex.testSync('  except Exception:')).toBeTruthy()
+    expect(decreaseIndentRegex.testSync('except Exception as e:')).toBeTruthy()
+    expect(decreaseIndentRegex.testSync('  except Exception as e:')).toBeTruthy()
+    expect(decreaseIndentRegex.testSync('finally:')).toBeTruthy()
+    expect(decreaseIndentRegex.testSync('  finally:')).toBeTruthy()
+    expect(decreaseIndentRegex.testSync('\t\t  finally:')).toBeTruthy()
+
+  it 'does not match lines incorrectly using the decreaseIndentPattern', ->
+    decreaseIndentRegex = languageMode.decreaseIndentRegexForScopeDescriptor(['source.python'])
+
+    # NOTE! This first one is different from most other rote tests here.
+    expect(decreaseIndentRegex.testSync('else: expression()')).toBeFalsy()
+    expect(decreaseIndentRegex.testSync('elif this_var == that_var')).toBeFalsy()
+    expect(decreaseIndentRegex.testSync('  elif this_var == that_var')).toBeFalsy()
+    expect(decreaseIndentRegex.testSync('else')).toBeFalsy()
+    expect(decreaseIndentRegex.testSync('  "finally:"')).toBeFalsy()
+
+
+  it 'matches lines correctly using the decreaseNextIndentPattern', ->
+    decreaseNextIndentRegex = languageMode.decreaseNextIndentRegexForScopeDescriptor(['source.python'])
+
+    expect(decreaseNextIndentRegex.testSync('  return')).toBeTruthy()
+    expect(decreaseNextIndentRegex.testSync('    return')).toBeTruthy()
+    expect(decreaseNextIndentRegex.testSync('    return x')).toBeTruthy()
+    expect(decreaseNextIndentRegex.testSync('    yield x')).toBeTruthy()
+    expect(decreaseNextIndentRegex.testSync('    yield expression()')).toBeTruthy()
+    expect(decreaseNextIndentRegex.testSync('    continue')).toBeTruthy()
+    expect(decreaseNextIndentRegex.testSync('    break')).toBeTruthy()
+    expect(decreaseNextIndentRegex.testSync('    raise')).toBeTruthy()
+    expect(decreaseNextIndentRegex.testSync('    raise Exception()')).toBeTruthy()

--- a/spec/language-python-spec.coffee
+++ b/spec/language-python-spec.coffee
@@ -74,7 +74,6 @@ describe 'Python settings', ->
     expect(decreaseIndentRegex.testSync('else')).toBeFalsy()
     expect(decreaseIndentRegex.testSync('  "finally:"')).toBeFalsy()
 
-
   it 'matches lines correctly using the decreaseNextIndentPattern', ->
     decreaseNextIndentRegex = languageMode.decreaseNextIndentRegexForScopeDescriptor(['source.python'])
 


### PR DESCRIPTION
### Description of the Change

* Add spec file for indentations. Modeled after https://github.com/atom/language-go/blob/master/spec/language-go-spec.coffee
* Dedent next line after some expressions (`pass|return|yield|continue|break|raise`)

### Alternate Designs

None.

### Benefits

Better support for the Python language.

### Possible Drawbacks

* yet another regex to run text on
* do you ever *not* want to dedent on one of `return|yield|continue|break|raise`?
* might break 3rd party python indentation packages, e.g. https://github.com/DSpeckhals/python-indent

### Applicable Issues

* https://github.com/DSpeckhals/python-indent/issues/20
* https://github.com/atom/atom/issues/12742
