### PR TITLE
Made some additions to the snippets

### DIFF
--- a/snippets/language-python.cson
+++ b/snippets/language-python.cson
@@ -2,6 +2,9 @@
   '#!/usr/bin/env python':
     'prefix': 'env'
     'body': '#!/usr/bin/env python\n'
+  '#!/usr/bin/env python3':
+    'prefix': 'env3'
+    'body': '#!/usr/bin/env python3\n'
   '# coding=utf-8':
     'prefix': 'enc'
     'body': '# -*- coding: utf-8 -*-\n'
@@ -52,7 +55,7 @@
     'body': 'self.fail(\'${1:message}\')$0'
   'New Class':
     'prefix': 'class'
-    'body': 'class ${1:ClassName}(${2:object}):\n\t"""${3:docstring for $1.}"""\n\tdef __init__(self, ${4:arg}):\n\t\t${5:super($1, self).__init__()}\n\t\tself.arg = arg\n\t\t$0'
+    'body': 'class ${1:ClassName}(${2:object}):\n\t"""${3:docstring for $1}"""\n\tdef __init__(self, ${4:arg}):\n\t\t${5:super($1, self).__init__()}\n\t\tself.arg = arg\n\t\t$0'
   'New Method':
     'prefix': 'defs'
     'body': 'def ${1:mname}(self, ${2:arg}):\n\t${3:pass}'
@@ -95,6 +98,9 @@
   'Dictionary Comprehension':
     'prefix': 'dc'
     'body': '{${1:key}: ${2:value} for ${3:key}, ${4:value} in ${5:variable}}'
+  'Set Comprehension':
+    'prefix': 'sc'
+    'body': '{${1:value} for ${2:value} in ${3:variable}}'
   'PDB set trace':
     'prefix': 'pdb'
     'body': 'import pdb; pdb.set_trace()'

--- a/snippets/language-python.cson
+++ b/snippets/language-python.cson
@@ -55,7 +55,7 @@
     'body': 'self.fail(\'${1:message}\')$0'
   'New Class':
     'prefix': 'class'
-    'body': 'class ${1:ClassName}(${2:object}):\n\t"""${3:docstring for $1}"""\n\tdef __init__(self, ${4:arg}):\n\t\t${5:super($1, self).__init__()}\n\t\tself.arg = arg\n\t\t$0'
+    'body': 'class ${1:ClassName}(${2:object}):\n\t"""${3:docstring for $1.}"""\n\tdef __init__(self, ${4:arg}):\n\t\t${5:super($1, self).__init__()}\n\t\tself.arg = arg\n\t\t$0'
   'New Method':
     'prefix': 'defs'
     'body': 'def ${1:mname}(self, ${2:arg}):\n\t${3:pass}'


### PR DESCRIPTION
### Description of the Change

Adds snippets for python 3 env header and set comprehension.

### Alternate Designs

No other designs for these were considered. These were modeled after the python env header and the list comprehension that already exit as snippets.

### Benefits

This minor improvement makes the snippet collection more complete and like all snippets provides easy access to perhaps frequently typed things with a few keystrokes.

### Possible Drawbacks

A possible drawback is that with the "env3" snippet one may write "env" and accidentally scroll down to env3 with a mouse or keyboard. This seems unlikely and not a huge problem even if it does happen.

### Applicable Issues

Fixes some minor annoyances.

Screenshots:

![Imgur](http://i.imgur.com/U4HBWvA.png "env3")

![Imgur](http://i.imgur.com/jytaw0O.png "sc")