### PR TITLE
Remove patterns for decreasing next indent level

### DIFF
--- a/settings/language-python.cson
+++ b/settings/language-python.cson
@@ -6,4 +6,3 @@
     'commentStart': '# '
     'increaseIndentPattern': '^\\s*(class|def|elif|else|except|finally|for|if|try|with|while)\\b.*:\\s*$'
     'decreaseIndentPattern': '^\\s*(elif|else|except|finally)\\b.*:\\s*$'
-    'decreaseNextIndentPattern': '^\\s*(pass|return|yield|continue|break|raise)\\b.*$'

--- a/spec/language-python-spec.coffee
+++ b/spec/language-python-spec.coffee
@@ -73,17 +73,3 @@ describe 'Python settings', ->
     expect(decreaseIndentRegex.testSync('  elif this_var == that_var')).toBeFalsy()
     expect(decreaseIndentRegex.testSync('else')).toBeFalsy()
     expect(decreaseIndentRegex.testSync('  "finally:"')).toBeFalsy()
-
-  it 'matches lines correctly using the decreaseNextIndentPattern', ->
-    decreaseNextIndentRegex = languageMode.decreaseNextIndentRegexForScopeDescriptor(['source.python'])
-
-    expect(decreaseNextIndentRegex.testSync('  return')).toBeTruthy()
-    expect(decreaseNextIndentRegex.testSync('    return')).toBeTruthy()
-    expect(decreaseNextIndentRegex.testSync('    return x')).toBeTruthy()
-    expect(decreaseNextIndentRegex.testSync('    yield x')).toBeTruthy()
-    expect(decreaseNextIndentRegex.testSync('    yield expression()')).toBeTruthy()
-    expect(decreaseNextIndentRegex.testSync('    continue')).toBeTruthy()
-    expect(decreaseNextIndentRegex.testSync('    break')).toBeTruthy()
-    expect(decreaseNextIndentRegex.testSync('    pass')).toBeTruthy()
-    expect(decreaseNextIndentRegex.testSync('    raise')).toBeTruthy()
-    expect(decreaseNextIndentRegex.testSync('    raise Exception()')).toBeTruthy()


### PR DESCRIPTION
This PR reverts the functional changes of #204.  Unfortunately, there is no way (yet) to tell if we're in an `if` block, which can lead to multiple dedenting in the following scenario:
```python
  if True:
    # something
    return
  # we are now at this indent level because of `decreaseNextIndentPattern`
else: # but typing `else:` will trigger another dedent from `decreaseIndentPattern`
```

I would argue that that is worse than having to shift-tab after a return that is not in an if statement.

/cc @kbrose

Fixes #209