### PR TITLE
Lowercase hex in str

### DIFF
--- a/grammars/python.cson
+++ b/grammars/python.cson
@@ -800,7 +800,7 @@
         'name': 'constant.character.escape.tab.python'
       '13':
         'name': 'constant.character.escape.vertical-tab.python'
-    'match': '(\\\\x[0-9A-F]{2})|(\\\\[0-7]{3})|(\\\\\\n)|(\\\\\\\\)|(\\\\\\")|(\\\\\')|(\\\\a)|(\\\\b)|(\\\\f)|(\\\\n)|(\\\\r)|(\\\\t)|(\\\\v)'
+    'match': '(\\\\x[0-9A-Fa-f]{2})|(\\\\[0-7]{3})|(\\\\\\n)|(\\\\\\\\)|(\\\\\\")|(\\\\\')|(\\\\a)|(\\\\b)|(\\\\f)|(\\\\n)|(\\\\r)|(\\\\t)|(\\\\v)'
   'escaped_unicode_char':
     'captures':
       '1':

--- a/spec/language-python-spec.coffee
+++ b/spec/language-python-spec.coffee
@@ -6,7 +6,7 @@ describe 'Python settings', ->
 
   beforeEach ->
     waitsForPromise ->
-      atom.workspace.open('sample.py').then (o) ->
+      atom.workspace.open().then (o) ->
         editor = o
         languageMode = editor.languageMode
 

--- a/spec/python-spec.coffee
+++ b/spec/python-spec.coffee
@@ -230,6 +230,21 @@ describe "Python grammar", ->
     expect(tokens[0][12].value).toBe ']'
     expect(tokens[0][12].scopes).toEqual ['source.python', 'meta.structure.list.python', 'punctuation.definition.list.end.python']
 
+  it "tokenizes a hex escape inside a string", ->
+    tokens = grammar.tokenizeLines('"\\x5A"')
+
+    expect(tokens[0][0].value).toBe '"'
+    expect(tokens[0][0].scopes).toEqual ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.begin.python']
+    expect(tokens[0][1].value).toBe '\\x5A'
+    expect(tokens[0][1].scopes).toEqual ['source.python', 'string.quoted.double.single-line.python', 'constant.character.escape.hex.python']
+
+    tokens = grammar.tokenizeLines('"\\x9f"')
+
+    expect(tokens[0][0].value).toBe '"'
+    expect(tokens[0][0].scopes).toEqual ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.begin.python']
+    expect(tokens[0][1].value).toBe '\\x9f'
+    expect(tokens[0][1].scopes).toEqual ['source.python', 'string.quoted.double.single-line.python', 'constant.character.escape.hex.python']
+
   it "tokenizes properties of self as self-type variables", ->
     tokens = grammar.tokenizeLines('self.foo')
 


### PR DESCRIPTION
### Description of the Change

Add lowercase letters to hex characters inside strings.

### Alternate Designs

None

### Benefits

Proper highlighting of lowercase hex letters such as

```python
s = '\x0a'
```

### Possible Drawbacks

None..................?

### Applicable Issues

https://github.com/atom/language-python/issues/200

Stagnant PR accomplishing same thing w/o tests: https://github.com/atom/language-python/pull/201
