### PR TITLE
Add tree-sitter Python grammar

### DIFF
--- a/grammars/tree-sitter-python.cson
+++ b/grammars/tree-sitter-python.cson
@@ -1,0 +1,92 @@
+id: 'python'
+name: 'Python'
+type: 'tree-sitter'
+parser: 'tree-sitter-python'
+
+fileTypes: [
+  'py'
+]
+
+folds: [
+  {
+    type: [
+      'if_statement'
+      'for_statement'
+      'try_statement'
+      'with_statement'
+      'while_statement'
+      'class_definition'
+      'function_definition'
+      'async_function_definition'
+    ]
+    start: {type: ':'}
+  }
+  {
+    start: {type: '(', index: 0}
+    end: {type: ')', index: -1}
+  },
+  {
+    start: {type: '[', index: 0}
+    end: {type: ']', index: -1}
+  },
+  {
+    start: {type: '{', index: 0}
+    end: {type: '}', index: -1}
+  }
+]
+
+comments:
+  start: '# '
+
+scopes:
+  'module': 'source.python'
+
+  'comment': 'comment.line'
+  'string': 'string.quoted'
+
+  'class_definition > identifier': 'entity.name.type.class'
+  'function_definition > identifier': 'entity.name.function'
+  'call > identifier:nth-child(0)': 'entity.name.function'
+  'call > attribute > identifier:nth-child(2)': 'entity.name.function'
+
+  'attribute > identifier:nth-child(2)': 'variable.other.object.property'
+
+  'decorator': 'entity.name.function.decorator'
+
+  'none': 'constant.language'
+  'true': 'constant.language'
+  'false': 'constant.language'
+
+  'type > identifier': 'support.storage.type'
+
+  '"class"': 'storage.type.class'
+  '"def"': 'storage.type.function'
+  '"lambda"': 'storage.type.function'
+
+  '"if"': 'keyword.control'
+  '"else"': 'keyword.control'
+  '"elif"': 'keyword.control'
+  '"while"': 'keyword.control'
+  '"for"': 'keyword.control'
+  '"return"': 'keyword.control'
+  '"break"': 'keyword.control'
+  '"continue"': 'keyword.control'
+  '"raise"': 'keyword.control'
+  '"try"': 'keyword.control'
+  '"except"': 'keyword.control'
+  '"with"': 'keyword.control'
+  '"as"': 'keyword.control'
+  '"finally"': 'keyword.control'
+  '"import"': 'keyword.control'
+  '"from"': 'keyword.control'
+
+  '"+"': 'keyword.operator'
+  '"-"': 'keyword.operator'
+  '"*"': 'keyword.operator'
+  '"/"': 'keyword.operator'
+  '"%"': 'keyword.operator'
+  '"in"': 'keyword.operator.in'
+  '"and"': 'keyword.operator.logical'
+  '"or"': 'keyword.operator.logical'
+  '"not"': 'keyword.operator.logical'
+  '"is"': 'keyword.operator.logical'

--- a/grammars/tree-sitter-python.cson
+++ b/grammars/tree-sitter-python.cson
@@ -2,6 +2,7 @@ id: 'python'
 name: 'Python'
 type: 'tree-sitter'
 parser: 'tree-sitter-python'
+legacyScopeName: 'source.python'
 
 fileTypes: [
   'py'

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
   "bugs": {
     "url": "https://github.com/atom/language-python/issues"
   },
+  "dependencies": {
+    "tree-sitter-python": "^0.2.0"
+  },
   "devDependencies": {
     "coffeelint": "^1.10.1"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-python",
-  "version": "0.45.5",
+  "version": "0.46.0-0",
   "engines": {
     "atom": "*",
     "node": "*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-python",
-  "version": "0.46.0-0",
+  "version": "0.46.0-1",
   "engines": {
     "atom": "*",
     "node": "*"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/atom/language-python/issues"
   },
   "dependencies": {
-    "tree-sitter-python": "^0.2.0"
+    "tree-sitter-python": "^0.3.0"
   },
   "devDependencies": {
     "coffeelint": "^1.10.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-python",
-  "version": "0.46.0-1",
+  "version": "0.46.0-2",
   "engines": {
     "atom": "*",
     "node": "*"


### PR DESCRIPTION
⚠️ Work In Progress ⚠️

This adds an alternative Python grammar that uses [tree-sitter-python](https://github.com/tree-sitter/tree-sitter-python) for parsing instead of [first-mate](https://github.com/atom/first-mate).