### PR TITLE
Clean up function calls

### DIFF
--- a/grammars/python.cson
+++ b/grammars/python.cson
@@ -406,57 +406,28 @@
     ]
   }
   {
-    'begin': '(?<=\\)|\\])\\s*(\\()'
+    'begin': '(?:([A-Za-z_][A-Za-z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z_0-9]*)*)|(?<=\\)|\\]))\\s*(\\()'
     'beginCaptures':
       '1':
+        'patterns': [
+          {
+            'include': '#dotted_name'
+          }
+        ]
+      '2':
         'name': 'punctuation.definition.arguments.begin.python'
-    'contentName': 'meta.function-call.arguments.python'
-    'end': '(\\))'
+    'end': '\\)'
     'endCaptures':
-      '1':
+      '0':
         'name': 'punctuation.definition.arguments.end.python'
     'name': 'meta.function-call.python'
+    'contentName': 'meta.function-call.arguments.python'
     'patterns': [
       {
         'include': '#keyword_arguments'
       }
       {
         'include': '$self'
-      }
-    ]
-  }
-  {
-    'begin': '(?=[A-Za-z_][A-Za-z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z_0-9]*)*\\s*\\()'
-    'end': '(\\))'
-    'endCaptures':
-      '1':
-        'name': 'punctuation.definition.arguments.end.python'
-    'name': 'meta.function-call.python'
-    'patterns': [
-      {
-        'begin': '(?=[A-Za-z_][A-Za-z0-9_]*(?:\\.[A-Za-z_][A-Za-z0-9_]*)*\\s*\\()'
-        'end': '(?=\\s*\\()'
-        'patterns': [
-          {
-            'include': '#dotted_name'
-          }
-        ]
-      }
-      {
-        'begin': '(\\()'
-        'beginCaptures':
-          '1':
-            'name': 'punctuation.definition.arguments.begin.python'
-        'contentName': 'meta.function-call.arguments.python'
-        'end': '(?=\\))'
-        'patterns': [
-          {
-            'include': '#keyword_arguments'
-          }
-          {
-            'include': '$self'
-          }
-        ]
       }
     ]
   }

--- a/spec/python-spec.coffee
+++ b/spec/python-spec.coffee
@@ -307,6 +307,22 @@ describe "Python grammar", ->
     expect(tokens[4][0]).toEqual value: ')', scopes: ['source.python', 'meta.function.python', 'punctuation.definition.parameters.end.python']
     expect(tokens[4][1]).toEqual value: ':', scopes: ['source.python', 'meta.function.python', 'punctuation.section.function.begin.python']
 
+  it "tokenizes complex function calls", ->
+    {tokens} = grammar.tokenizeLine "torch.nn.BCELoss()(Variable(bayes_optimal_prob, 1, requires_grad=False), Yvar).data[0]"
+
+    expect(tokens[4]).toEqual value: 'BCELoss', scopes: ['source.python', 'meta.function-call.python']
+    expect(tokens[5]).toEqual value: '(', scopes: ['source.python', 'meta.function-call.python', 'punctuation.definition.arguments.begin.python']
+    expect(tokens[6]).toEqual value: ')', scopes: ['source.python', 'meta.function-call.python', 'punctuation.definition.arguments.end.python']
+    expect(tokens[7]).toEqual value: '(', scopes: ['source.python', 'meta.function-call.python', 'punctuation.definition.arguments.begin.python']
+    expect(tokens[8]).toEqual value: 'Variable', scopes: ['source.python', 'meta.function-call.python', 'meta.function-call.arguments.python', 'meta.function-call.python']
+    expect(tokens[9]).toEqual value: '(', scopes: ['source.python', 'meta.function-call.python', 'meta.function-call.arguments.python', 'meta.function-call.python', 'punctuation.definition.arguments.begin.python']
+    expect(tokens[10]).toEqual value: 'bayes_optimal_prob', scopes: ['source.python', 'meta.function-call.python', 'meta.function-call.arguments.python', 'meta.function-call.python', 'meta.function-call.arguments.python']
+    expect(tokens[14]).toEqual value: 'requires_grad', scopes: ['source.python', 'meta.function-call.python', 'meta.function-call.arguments.python', 'meta.function-call.python', 'meta.function-call.arguments.python', 'variable.parameter.function.python']
+    expect(tokens[16]).toEqual value: 'False', scopes: ['source.python', 'meta.function-call.python', 'meta.function-call.arguments.python', 'meta.function-call.python', 'meta.function-call.arguments.python', 'constant.language.python']
+    expect(tokens[17]).toEqual value: ')', scopes: ['source.python', 'meta.function-call.python', 'meta.function-call.arguments.python', 'meta.function-call.python', 'punctuation.definition.arguments.end.python']
+    expect(tokens[18]).toEqual value: ', ', scopes: ['source.python', 'meta.function-call.python', 'meta.function-call.arguments.python']
+    expect(tokens[20]).toEqual value: ')', scopes: ['source.python', 'meta.function-call.python', 'punctuation.definition.arguments.end.python']
+    expect(tokens[21]).toEqual value: '.', scopes: ['source.python']
 
   it "tokenizes SQL inline highlighting on blocks", ->
     delimsByScope =


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

* Removed excessive usage of lookaheads in function-call pattern
* Due to the above, combined the two separate function-call patterns into one

I am not exactly sure why removing the lookaheads solved #218, but it's not unreasonable that the nested lookaheads were causing problems with the recursive `$self` lookups.

### Alternate Designs

None.

### Benefits

Cleaner patterns and a fixed bug.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #218