### PR TITLE
Level up string formatting

### DIFF
--- a/grammars/python.cson
+++ b/grammars/python.cson
@@ -848,7 +848,6 @@
       }
     ]
   'string_formatting':
-    # TODO: Add $self highlighting?
     'match': '''(?x)
       # https://docs.python.org/2/library/stdtypes.html#string-formatting (deprecated)
       %

--- a/grammars/python.cson
+++ b/grammars/python.cson
@@ -852,7 +852,7 @@
       # https://docs.python.org/2/library/stdtypes.html#string-formatting (deprecated)
       %
       (\\([a-zA-Z_]+\\))?             # mapping key
-      [#0+\\- ]?                      # conversion flags
+      [#0+\\- ]?                      # conversion flags (space at the end is intentional)
       (\\d+|\\*)?                     # minimum field width
       (\\.(\\d+|\\*))?                # precision
       [hlL]?                          # length modifier

--- a/grammars/python.cson
+++ b/grammars/python.cson
@@ -855,7 +855,7 @@
       (\\([a-zA-Z_]+\\))?             # mapping key
       [#0+\\- ]?                      # conversion flags
       (\\d+|\\*)?                     # minimum field width
-      (\\.(\\d+)|\\*)?                # precision
+      (\\.(\\d+|\\*))?                # precision
       [hlL]?                          # length modifier
       [diouxXeEfFgGcrs%]              # conversion type
       |

--- a/grammars/python.cson
+++ b/grammars/python.cson
@@ -628,9 +628,6 @@
   'builtin_types':
     'match': '(?x)\\b(\n\t\t\t\tbasestring|bool|buffer|bytearray|bytes|complex|dict|float|frozenset|int|\n\t\t\t\tlist|long|memoryview|object|range|set|slice|str|tuple|unicode|xrange\n\t\t\t)\\b'
     'name': 'support.type.python'
-  'constant_placeholder':
-    'match': '(?i:(%(\\([a-z_]+\\))?#?0?\\-?[ ]?\\+?([0-9]*|\\*)(\\.([0-9]*|\\*))?([hL][a-z]|[a-z%]))|(\\{([!\\[\\].:\\w ]+)?\\}))'
-    'name': 'constant.other.placeholder.python'
   'docstrings':
     'patterns': [
       {
@@ -850,6 +847,47 @@
         'include': 'source.regexp.python'
       }
     ]
+  'string_formatting':
+    # TODO: Add $self highlighting?
+    'match': '''(?x)
+      # https://docs.python.org/2/library/stdtypes.html#string-formatting (deprecated)
+      %
+      (\\([a-zA-Z_]+\\))?             # mapping key
+      [#0+\\- ]?                      # conversion flags
+      (\\d+|\\*)?                     # minimum field width
+      (\\.(\\d+)|\\*)?                # precision
+      [hlL]?                          # length modifier
+      [diouxXeEfFgGcrs%]              # conversion type
+      |
+      # https://docs.python.org/3/library/string.html#format-string-syntax
+      {
+        (
+          (
+            \\d                       # integer
+            |
+            [a-zA-Z_]\\w*             # identifier
+          )
+          (
+            \\.[a-zA-Z_]\\w*          # attribute name
+            |
+            \\[[^\\]]+\\]             # element index
+          )*
+        )?
+        (![rsa])?                     # conversion
+        (
+          :
+          (.?[<>=^])?                 # fill followed by align
+          [+\\- ]?                    # sign (space at the end is intentional)
+          \\#?                        # alternate form
+          0?
+          \\d*                        # width
+          [_,]?                       # grouping option
+          (\\.\\d+)?                  # precision
+          [bcdeEfFgGnosxX%]?          # type
+        )?
+      }
+    '''
+    'name': 'constant.other.placeholder.python'
   'string_quoted_double':
     'patterns': [
       {
@@ -869,7 +907,7 @@
         'name': 'string.quoted.double.block.unicode-raw-regex.python'
         'patterns': [
           {
-            'include': '#constant_placeholder'
+            'include': '#string_formatting'
           }
           {
             'include': '#escaped_unicode_char'
@@ -899,7 +937,7 @@
         'name': 'string.quoted.double.block.unicode-raw.python'
         'patterns': [
           {
-            'include': '#constant_placeholder'
+            'include': '#string_formatting'
           }
           {
             'include': '#escaped_unicode_char'
@@ -926,7 +964,7 @@
         'name': 'string.quoted.double.block.raw-regex.python'
         'patterns': [
           {
-            'include': '#constant_placeholder'
+            'include': '#string_formatting'
           }
           {
             'include': '#escaped_char'
@@ -953,7 +991,7 @@
         'name': 'string.quoted.double.block.raw.python'
         'patterns': [
           {
-            'include': '#constant_placeholder'
+            'include': '#string_formatting'
           }
           {
             'include': '#escaped_char'
@@ -977,7 +1015,7 @@
         'name': 'string.quoted.double.block.unicode.python'
         'patterns': [
           {
-            'include': '#constant_placeholder'
+            'include': '#string_formatting'
           }
           {
             'include': '#escaped_unicode_char'
@@ -995,7 +1033,7 @@
             'name': 'punctuation.definition.string.begin.python'
           '3':
             'patterns': [
-              {'include': '#constant_placeholder'}
+              {'include': '#string_formatting'}
               {'include': '#escaped_unicode_char'}
               {'include': '#escaped_char'}
               {'include': '#regular_expressions'}
@@ -1025,7 +1063,7 @@
         'name': 'string.quoted.double.single-line.unicode-raw.python'
         'patterns': [
           {
-            'include': '#constant_placeholder'
+            'include': '#string_formatting'
           }
           {
             'include': '#escaped_unicode_char'
@@ -1043,7 +1081,7 @@
             'name': 'punctuation.definition.string.begin.python'
           '3':
             'patterns': [
-              {'include': '#constant_placeholder'}
+              {'include': '#string_formatting'}
               {'include': '#escaped_char'}
               {'include': '#regular_expressions'}
             ]
@@ -1072,7 +1110,7 @@
         'name': 'string.quoted.double.single-line.raw.python'
         'patterns': [
           {
-            'include': '#constant_placeholder'
+            'include': '#string_formatting'
           }
           {
             'include': '#escaped_char'
@@ -1098,7 +1136,7 @@
         'name': 'string.quoted.double.single-line.unicode.python'
         'patterns': [
           {
-            'include': '#constant_placeholder'
+            'include': '#string_formatting'
           }
           {
             'include': '#escaped_unicode_char'
@@ -1132,7 +1170,7 @@
              ]
           }
           {
-            'include': '#constant_placeholder'
+            'include': '#string_formatting'
           }
           {
             'include': '#escaped_char'
@@ -1156,7 +1194,7 @@
         'name': 'string.quoted.double.single-line.sql.python'
         'patterns': [
           {
-            'include': '#constant_placeholder'
+            'include': '#string_formatting'
           }
           {
             'include': '#escaped_char'
@@ -1181,7 +1219,7 @@
         'name': 'string.quoted.double.block.python'
         'patterns': [
           {
-            'include': '#constant_placeholder'
+            'include': '#string_formatting'
           }
           {
             'include': '#escaped_char'
@@ -1205,7 +1243,7 @@
         'name': 'string.quoted.double.single-line.python'
         'patterns': [
           {
-            'include': '#constant_placeholder'
+            'include': '#string_formatting'
           }
           {
             'include': '#escaped_char'
@@ -1243,7 +1281,7 @@
         'name': 'string.quoted.single.block.unicode-raw-regex.python'
         'patterns': [
           {
-            'include': '#constant_placeholder'
+            'include': '#string_formatting'
           }
           {
             'include': '#escaped_unicode_char'
@@ -1273,7 +1311,7 @@
         'name': 'string.quoted.single.block.unicode-raw.python'
         'patterns': [
           {
-            'include': '#constant_placeholder'
+            'include': '#string_formatting'
           }
           {
             'include': '#escaped_unicode_char'
@@ -1300,7 +1338,7 @@
         'name': 'string.quoted.single.block.raw-regex.python'
         'patterns': [
           {
-            'include': '#constant_placeholder'
+            'include': '#string_formatting'
           }
           {
             'include': '#escaped_char'
@@ -1327,7 +1365,7 @@
         'name': 'string.quoted.single.block.raw.python'
         'patterns': [
           {
-            'include': '#constant_placeholder'
+            'include': '#string_formatting'
           }
           {
             'include': '#escaped_char'
@@ -1351,7 +1389,7 @@
         'name': 'string.quoted.single.block.unicode.python'
         'patterns': [
           {
-            'include': '#constant_placeholder'
+            'include': '#string_formatting'
           }
           {
             'include': '#escaped_unicode_char'
@@ -1369,7 +1407,7 @@
             'name': 'punctuation.definition.string.begin.python'
           '3':
             'patterns': [
-              {'include': '#constant_placeholder'}
+              {'include': '#string_formatting'}
               {'include': '#escaped_unicode_char'}
               {'include': '#escaped_char'}
               {'include': '#regular_expressions'}
@@ -1397,7 +1435,7 @@
         'name': 'string.quoted.single.single-line.unicode-raw.python'
         'patterns': [
           {
-            'include': '#constant_placeholder'
+            'include': '#string_formatting'
           }
           {
             'include': '#escaped_unicode_char'
@@ -1415,7 +1453,7 @@
             'name': 'punctuation.definition.string.begin.python'
           '3':
             'patterns': [
-              {'include': '#constant_placeholder'}
+              {'include': '#string_formatting'}
               {'include': '#escaped_char'}
               {'include': '#regular_expressions'}
             ]
@@ -1442,7 +1480,7 @@
         'name': 'string.quoted.single.single-line.raw.python'
         'patterns': [
           {
-            'include': '#constant_placeholder'
+            'include': '#string_formatting'
           }
           {
             'include': '#escaped_char'
@@ -1466,7 +1504,7 @@
         'name': 'string.quoted.single.single-line.unicode.python'
         'patterns': [
           {
-            'include': '#constant_placeholder'
+            'include': '#string_formatting'
           }
           {
             'include': '#escaped_unicode_char'
@@ -1500,7 +1538,7 @@
              ]
           }
           {
-            'include': '#constant_placeholder'
+            'include': '#string_formatting'
           }
           {
             'include': '#escaped_char'
@@ -1522,7 +1560,7 @@
         'name': 'string.quoted.single.single-line.python'
         'patterns': [
           {
-            'include': '#constant_placeholder'
+            'include': '#string_formatting'
           }
           {
             'include': '#escaped_char'
@@ -1547,7 +1585,7 @@
         'name': 'string.quoted.single.block.python'
         'patterns': [
           {
-            'include': '#constant_placeholder'
+            'include': '#string_formatting'
           }
           {
             'include': '#escaped_char'
@@ -1569,7 +1607,7 @@
         'name': 'string.quoted.single.single-line.python'
         'patterns': [
           {
-            'include': '#constant_placeholder'
+            'include': '#string_formatting'
           }
           {
             'include': '#escaped_char'

--- a/spec/python-spec.coffee
+++ b/spec/python-spec.coffee
@@ -245,6 +245,208 @@ describe "Python grammar", ->
     expect(tokens[0][1].value).toBe '\\x9f'
     expect(tokens[0][1].scopes).toEqual ['source.python', 'string.quoted.double.single-line.python', 'constant.character.escape.hex.python']
 
+  describe "string formatting", ->
+    describe "%-style formatting", ->
+      it "tokenizes the conversion type", ->
+        {tokens} = grammar.tokenizeLine '"%d"'
+
+        expect(tokens[0]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.begin.python']
+        expect(tokens[1]).toEqual value: '%d', scopes: ['source.python', 'string.quoted.double.single-line.python', 'constant.other.placeholder.python']
+        expect(tokens[2]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.end.python']
+
+      it "tokenizes an optional mapping key", ->
+        {tokens} = grammar.tokenizeLine '"%(key)x"'
+
+        expect(tokens[0]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.begin.python']
+        expect(tokens[1]).toEqual value: '%(key)x', scopes: ['source.python', 'string.quoted.double.single-line.python', 'constant.other.placeholder.python']
+        expect(tokens[2]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.end.python']
+
+      it "tokenizes an optional conversion flag", ->
+        {tokens} = grammar.tokenizeLine '"% F"'
+
+        expect(tokens[0]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.begin.python']
+        expect(tokens[1]).toEqual value: '% F', scopes: ['source.python', 'string.quoted.double.single-line.python', 'constant.other.placeholder.python']
+        expect(tokens[2]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.end.python']
+
+      it "tokenizes an optional field width", ->
+        {tokens} = grammar.tokenizeLine '"%11s"'
+
+        expect(tokens[0]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.begin.python']
+        expect(tokens[1]).toEqual value: '%11s', scopes: ['source.python', 'string.quoted.double.single-line.python', 'constant.other.placeholder.python']
+        expect(tokens[2]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.end.python']
+
+      it "tokenizes * as the optional field width", ->
+        {tokens} = grammar.tokenizeLine '"%*g"'
+
+        expect(tokens[0]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.begin.python']
+        expect(tokens[1]).toEqual value: '%*g', scopes: ['source.python', 'string.quoted.double.single-line.python', 'constant.other.placeholder.python']
+        expect(tokens[2]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.end.python']
+
+      it "tokenizes an optional precision", ->
+        {tokens} = grammar.tokenizeLine '"%.4r"'
+
+        expect(tokens[0]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.begin.python']
+        expect(tokens[1]).toEqual value: '%.4r', scopes: ['source.python', 'string.quoted.double.single-line.python', 'constant.other.placeholder.python']
+        expect(tokens[2]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.end.python']
+
+      it "tokenizes * as the optional precision", ->
+        {tokens} = grammar.tokenizeLine '"%.*%"'
+
+        expect(tokens[0]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.begin.python']
+        expect(tokens[1]).toEqual value: '%.*%', scopes: ['source.python', 'string.quoted.double.single-line.python', 'constant.other.placeholder.python']
+        expect(tokens[2]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.end.python']
+
+      it "tokenizes an optional length modifier", ->
+        {tokens} = grammar.tokenizeLine '"%Lo"'
+
+        expect(tokens[0]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.begin.python']
+        expect(tokens[1]).toEqual value: '%Lo', scopes: ['source.python', 'string.quoted.double.single-line.python', 'constant.other.placeholder.python']
+        expect(tokens[2]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.end.python']
+
+      it "tokenizes complex formats", ->
+        {tokens} = grammar.tokenizeLine '"%(key)#5.*hc"'
+
+        expect(tokens[0]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.begin.python']
+        expect(tokens[1]).toEqual value: '%(key)#5.*hc', scopes: ['source.python', 'string.quoted.double.single-line.python', 'constant.other.placeholder.python']
+        expect(tokens[2]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.end.python']
+
+    describe "{}-style formatting", ->
+      it "tokenizes the empty replacement field", ->
+        {tokens} = grammar.tokenizeLine '"{}"'
+
+        expect(tokens[0]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.begin.python']
+        expect(tokens[1]).toEqual value: '{}', scopes: ['source.python', 'string.quoted.double.single-line.python', 'constant.other.placeholder.python']
+        expect(tokens[2]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.end.python']
+
+      it "tokenizes a number as the field name", ->
+        {tokens} = grammar.tokenizeLine '"{1}"'
+
+        expect(tokens[0]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.begin.python']
+        expect(tokens[1]).toEqual value: '{1}', scopes: ['source.python', 'string.quoted.double.single-line.python', 'constant.other.placeholder.python']
+        expect(tokens[2]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.end.python']
+
+      it "tokenizes a variable name as the field name", ->
+        {tokens} = grammar.tokenizeLine '"{key}"'
+
+        expect(tokens[0]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.begin.python']
+        expect(tokens[1]).toEqual value: '{key}', scopes: ['source.python', 'string.quoted.double.single-line.python', 'constant.other.placeholder.python']
+        expect(tokens[2]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.end.python']
+
+      it "tokenizes field name attributes", ->
+        {tokens} = grammar.tokenizeLine '"{key.length}"'
+
+        expect(tokens[0]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.begin.python']
+        expect(tokens[1]).toEqual value: '{key.length}', scopes: ['source.python', 'string.quoted.double.single-line.python', 'constant.other.placeholder.python']
+        expect(tokens[2]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.end.python']
+
+        {tokens} = grammar.tokenizeLine '"{4.width}"'
+
+        expect(tokens[0]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.begin.python']
+        expect(tokens[1]).toEqual value: '{4.width}', scopes: ['source.python', 'string.quoted.double.single-line.python', 'constant.other.placeholder.python']
+        expect(tokens[2]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.end.python']
+
+        {tokens} = grammar.tokenizeLine '"{python2[\'3\']}"'
+
+        expect(tokens[0]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.begin.python']
+        expect(tokens[1]).toEqual value: '{python2[\'3\']}', scopes: ['source.python', 'string.quoted.double.single-line.python', 'constant.other.placeholder.python']
+        expect(tokens[2]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.end.python']
+
+        {tokens} = grammar.tokenizeLine '"{2[4]}"'
+
+        expect(tokens[0]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.begin.python']
+        expect(tokens[1]).toEqual value: '{2[4]}', scopes: ['source.python', 'string.quoted.double.single-line.python', 'constant.other.placeholder.python']
+        expect(tokens[2]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.end.python']
+
+      it "tokenizes multiple field name attributes", ->
+        {tokens} = grammar.tokenizeLine '"{nested.a[2][\'val\'].value}"'
+
+        expect(tokens[0]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.begin.python']
+        expect(tokens[1]).toEqual value: '{nested.a[2][\'val\'].value}', scopes: ['source.python', 'string.quoted.double.single-line.python', 'constant.other.placeholder.python']
+        expect(tokens[2]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.end.python']
+
+      it "tokenizes conversions", ->
+        {tokens} = grammar.tokenizeLine '"{!r}"'
+
+        expect(tokens[0]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.begin.python']
+        expect(tokens[1]).toEqual value: '{!r}', scopes: ['source.python', 'string.quoted.double.single-line.python', 'constant.other.placeholder.python']
+        expect(tokens[2]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.end.python']
+
+      describe "format specifiers", ->
+        it "tokenizes alignment", ->
+          {tokens} = grammar.tokenizeLine '"{:<}"'
+
+          expect(tokens[0]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.begin.python']
+          expect(tokens[1]).toEqual value: '{:<}', scopes: ['source.python', 'string.quoted.double.single-line.python', 'constant.other.placeholder.python']
+          expect(tokens[2]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.end.python']
+
+          {tokens} = grammar.tokenizeLine '"{:a^}"'
+
+          expect(tokens[0]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.begin.python']
+          expect(tokens[1]).toEqual value: '{:a^}', scopes: ['source.python', 'string.quoted.double.single-line.python', 'constant.other.placeholder.python']
+          expect(tokens[2]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.end.python']
+
+        it "tokenizes signs", ->
+          {tokens} = grammar.tokenizeLine '"{:+}"'
+
+          expect(tokens[0]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.begin.python']
+          expect(tokens[1]).toEqual value: '{:+}', scopes: ['source.python', 'string.quoted.double.single-line.python', 'constant.other.placeholder.python']
+          expect(tokens[2]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.end.python']
+
+          {tokens} = grammar.tokenizeLine '"{: }"'
+
+          expect(tokens[0]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.begin.python']
+          expect(tokens[1]).toEqual value: '{: }', scopes: ['source.python', 'string.quoted.double.single-line.python', 'constant.other.placeholder.python']
+          expect(tokens[2]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.end.python']
+
+        it "tokenizes the alternate form indicator", ->
+          {tokens} = grammar.tokenizeLine '"{:#}"'
+
+          expect(tokens[0]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.begin.python']
+          expect(tokens[1]).toEqual value: '{:#}', scopes: ['source.python', 'string.quoted.double.single-line.python', 'constant.other.placeholder.python']
+          expect(tokens[2]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.end.python']
+
+        it "tokenizes 0", ->
+          {tokens} = grammar.tokenizeLine '"{:0}"'
+
+          expect(tokens[0]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.begin.python']
+          expect(tokens[1]).toEqual value: '{:0}', scopes: ['source.python', 'string.quoted.double.single-line.python', 'constant.other.placeholder.python']
+          expect(tokens[2]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.end.python']
+
+        it "tokenizes the width", ->
+          {tokens} = grammar.tokenizeLine '"{:34}"'
+
+          expect(tokens[0]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.begin.python']
+          expect(tokens[1]).toEqual value: '{:34}', scopes: ['source.python', 'string.quoted.double.single-line.python', 'constant.other.placeholder.python']
+          expect(tokens[2]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.end.python']
+
+        it "tokenizes the grouping option", ->
+          {tokens} = grammar.tokenizeLine '"{:,}"'
+
+          expect(tokens[0]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.begin.python']
+          expect(tokens[1]).toEqual value: '{:,}', scopes: ['source.python', 'string.quoted.double.single-line.python', 'constant.other.placeholder.python']
+          expect(tokens[2]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.end.python']
+
+        it "tokenizes the precision", ->
+          {tokens} = grammar.tokenizeLine '"{:.5}"'
+
+          expect(tokens[0]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.begin.python']
+          expect(tokens[1]).toEqual value: '{:.5}', scopes: ['source.python', 'string.quoted.double.single-line.python', 'constant.other.placeholder.python']
+          expect(tokens[2]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.end.python']
+
+        it "tokenizes the type", ->
+          {tokens} = grammar.tokenizeLine '"{:b}"'
+
+          expect(tokens[0]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.begin.python']
+          expect(tokens[1]).toEqual value: '{:b}', scopes: ['source.python', 'string.quoted.double.single-line.python', 'constant.other.placeholder.python']
+          expect(tokens[2]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.end.python']
+
+      it "tokenizes complex formats", ->
+        {tokens} = grammar.tokenizeLine '"{0.players[2]!a:2>-#01_.3d}"'
+
+        expect(tokens[0]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.begin.python']
+        expect(tokens[1]).toEqual value: '{0.players[2]!a:2>-#01_.3d}', scopes: ['source.python', 'string.quoted.double.single-line.python', 'constant.other.placeholder.python']
+        expect(tokens[2]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.end.python']
+
   it "tokenizes properties of self as self-type variables", ->
     tokens = grammar.tokenizeLines('self.foo')
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

The string formatting rules have been updated according to the two official specs, https://docs.python.org/2/library/stdtypes.html#string-formatting for the deprecated `%` style and 
https://docs.python.org/3/library/string.html#format-string-syntax for the new `{}` style.

### Alternate Designs

None.

### Benefits

By being in line with the specs, a number of formatting-related bugs should be fixed.

### Possible Drawbacks

* The `%` spec is a bit ambiguous (for example, what constitutes a "sequence of characters"?) so it is possible that I misinterpreted parts of it.
* While not explicitly stated in the `{}` spec, it appears that nested formatting is possible.  That is not yet supported by this PR.

### Applicable Issues

Fixes #211
Fixes #115
Fixes #71