### PR TITLE
Tokenize {{ and }} as escape characters

### DIFF
--- a/grammars/python.cson
+++ b/grammars/python.cson
@@ -742,6 +742,21 @@
       }
     ]
   'escaped_char':
+    'match': '''(?x)
+      (\\\\x[0-9A-Fa-f]{2})|
+      (\\\\[0-7]{3})|(\\\\\\n)|
+      (\\\\\\\\)|
+      (\\\\\\")|
+      (\\\\\')|
+      (\\\\a)|
+      (\\\\b)|
+      (\\\\f)|
+      (\\\\n)|
+      (\\\\r)|
+      (\\\\t)|
+      (\\\\v)|
+      ({{|}})
+    '''
     'captures':
       '1':
         'name': 'constant.character.escape.hex.python'
@@ -769,7 +784,8 @@
         'name': 'constant.character.escape.tab.python'
       '13':
         'name': 'constant.character.escape.vertical-tab.python'
-    'match': '(\\\\x[0-9A-Fa-f]{2})|(\\\\[0-7]{3})|(\\\\\\n)|(\\\\\\\\)|(\\\\\\")|(\\\\\')|(\\\\a)|(\\\\b)|(\\\\f)|(\\\\n)|(\\\\r)|(\\\\t)|(\\\\v)'
+      '14':
+        'name': 'constant.character.escape.curly-bracket.python'
   'escaped_unicode_char':
     'captures':
       '1':

--- a/spec/python-spec.coffee
+++ b/spec/python-spec.coffee
@@ -447,6 +447,15 @@ describe "Python grammar", ->
         expect(tokens[1]).toEqual value: '{0.players[2]!a:2>-#01_.3d}', scopes: ['source.python', 'string.quoted.double.single-line.python', 'constant.other.placeholder.python']
         expect(tokens[2]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.end.python']
 
+      it "tokenizes {{ and }} as escape characters and not formatters", ->
+        {tokens} = grammar.tokenizeLine '"{{hello}}"'
+
+        expect(tokens[0]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.begin.python']
+        expect(tokens[1]).toEqual value: '{{', scopes: ['source.python', 'string.quoted.double.single-line.python', 'constant.character.escape.curly-bracket.python']
+        expect(tokens[2]).toEqual value: 'hello', scopes: ['source.python', 'string.quoted.double.single-line.python']
+        expect(tokens[3]).toEqual value: '}}', scopes: ['source.python', 'string.quoted.double.single-line.python', 'constant.character.escape.curly-bracket.python']
+        expect(tokens[4]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.end.python']
+
   it "tokenizes properties of self as self-type variables", ->
     tokens = grammar.tokenizeLines('self.foo')
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

`'{{test}}'` does not indicate a format specifier but rather escaped curly brackets.

### Alternate Designs

None.

### Benefits

Curly bracket escapes will be recognized in strings.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #182