### PR TITLE
Do not recursively match character classes

### DIFF
--- a/grammars/regular expressions (python).cson
+++ b/grammars/regular expressions (python).cson
@@ -1,10 +1,10 @@
-'comment': 'Matches Python\'s regular expression syntax.'
+'name': 'Regular Expressions (Python)'
+'scopeName': 'source.regexp.python'
+'foldingStartMarker': '(/\\*|\\{|\\()'
+'foldingStopMarker': '(\\*/|\\}|\\))'
 'fileTypes': [
   're'
 ]
-'foldingStartMarker': '(/\\*|\\{|\\()'
-'foldingStopMarker': '(\\*/|\\}|\\))'
-'name': 'Regular Expressions (Python)'
 'patterns': [
   {
     'match': '\\\\[bBAZzG]|\\^|\\$'
@@ -109,14 +109,20 @@
     ]
   }
   {
-    'include': '#character-class'
-  }
-]
-'repository':
-  'character-class':
+    'begin': '(\\[)(\\^)?'
+    'beginCaptures':
+      '1':
+        'name': 'punctuation.definition.character-class.begin.regexp'
+      '2':
+        'name': 'keyword.operator.negation.regexp'
+    'end': '\\]'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.character-class.end.regexp'
+    'name': 'constant.other.character-class.set.regexp'
     'patterns': [
       {
-        'match': '\\\\[wWsSdDhH]|\\.'
+        'match': '\\\\[wWsSdDhH]'
         'name': 'constant.character.character-class.regexp'
       }
       {
@@ -124,31 +130,14 @@
         'name': 'constant.character.escape.backslash.regexp'
       }
       {
-        'begin': '(\\[)(\\^)?'
-        'beginCaptures':
-          '1':
-            'name': 'punctuation.definition.character-class.regexp'
+        'captures':
           '2':
-            'name': 'keyword.operator.negation.regexp'
-        'end': '(\\])'
-        'endCaptures':
-          '1':
-            'name': 'punctuation.definition.character-class.regexp'
-        'name': 'constant.other.character-class.set.regexp'
-        'patterns': [
-          {
-            'include': '#character-class'
-          }
-          {
-            'captures':
-              '2':
-                'name': 'constant.character.escape.backslash.regexp'
-              '4':
-                'name': 'constant.character.escape.backslash.regexp'
-            'match': '((\\\\.)|.)\\-((\\\\.)|[^\\]])'
-            'name': 'constant.other.character-class.range.regexp'
-          }
-        ]
+            'name': 'constant.character.escape.backslash.regexp'
+          '4':
+            'name': 'constant.character.escape.backslash.regexp'
+        'match': '((\\\\.)|.)\\-((\\\\.)|[^\\]])'
+        'name': 'constant.other.character-class.range.regexp'
       }
     ]
-'scopeName': 'source.regexp.python'
+  }
+]

--- a/grammars/regular expressions (python).cson
+++ b/grammars/regular expressions (python).cson
@@ -115,7 +115,7 @@
         'name': 'punctuation.definition.character-class.begin.regexp'
       '2':
         'name': 'keyword.operator.negation.regexp'
-    'end': '\\]'
+    'end': '(?!\\G)\\]' # Character classes cannot be empty (if the first character is a ] it is treated literally)
     'endCaptures':
       '0':
         'name': 'punctuation.definition.character-class.end.regexp'

--- a/spec/python-regex-spec.coffee
+++ b/spec/python-regex-spec.coffee
@@ -16,3 +16,9 @@ describe 'Python regular expression grammar', ->
       expect(tokens[2]).toEqual value: '\\]', scopes: ['source.regexp.python', 'constant.other.character-class.set.regexp', 'constant.character.escape.backslash.regexp']
       expect(tokens[3]).toEqual value: '@', scopes: ['source.regexp.python', 'constant.other.character-class.set.regexp']
       expect(tokens[4]).toEqual value: ']', scopes: ['source.regexp.python', 'constant.other.character-class.set.regexp', 'punctuation.definition.character-class.end.regexp']
+
+    it 'does not end the character class early if the first character is a ]', ->
+      {tokens} = grammar.tokenizeLine '[][]'
+      expect(tokens[0]).toEqual value: '[', scopes: ['source.regexp.python', 'constant.other.character-class.set.regexp', 'punctuation.definition.character-class.begin.regexp']
+      expect(tokens[1]).toEqual value: '][', scopes: ['source.regexp.python', 'constant.other.character-class.set.regexp']
+      expect(tokens[2]).toEqual value: ']', scopes: ['source.regexp.python', 'constant.other.character-class.set.regexp', 'punctuation.definition.character-class.end.regexp']

--- a/spec/python-regex-spec.coffee
+++ b/spec/python-regex-spec.coffee
@@ -22,3 +22,9 @@ describe 'Python regular expression grammar', ->
       expect(tokens[0]).toEqual value: '[', scopes: ['source.regexp.python', 'constant.other.character-class.set.regexp', 'punctuation.definition.character-class.begin.regexp']
       expect(tokens[1]).toEqual value: '][', scopes: ['source.regexp.python', 'constant.other.character-class.set.regexp']
       expect(tokens[2]).toEqual value: ']', scopes: ['source.regexp.python', 'constant.other.character-class.set.regexp', 'punctuation.definition.character-class.end.regexp']
+
+      {tokens} = grammar.tokenizeLine '[^][]'
+      expect(tokens[0]).toEqual value: '[', scopes: ['source.regexp.python', 'constant.other.character-class.set.regexp', 'punctuation.definition.character-class.begin.regexp']
+      expect(tokens[1]).toEqual value: '^', scopes: ['source.regexp.python', 'constant.other.character-class.set.regexp', 'keyword.operator.negation.regexp']
+      expect(tokens[2]).toEqual value: '][', scopes: ['source.regexp.python', 'constant.other.character-class.set.regexp']
+      expect(tokens[3]).toEqual value: ']', scopes: ['source.regexp.python', 'constant.other.character-class.set.regexp', 'punctuation.definition.character-class.end.regexp']

--- a/spec/python-regex-spec.coffee
+++ b/spec/python-regex-spec.coffee
@@ -1,0 +1,18 @@
+describe 'Python regular expression grammar', ->
+  grammar = null
+
+  beforeEach ->
+    waitsForPromise ->
+      atom.packages.activatePackage('language-python')
+
+    runs ->
+      grammar = atom.grammars.grammarForScopeName('source.regexp.python')
+
+  describe 'character classes', ->
+    it 'does not recursively match character classes', ->
+      {tokens} = grammar.tokenizeLine '[.:[\\]@]'
+      expect(tokens[0]).toEqual value: '[', scopes: ['source.regexp.python', 'constant.other.character-class.set.regexp', 'punctuation.definition.character-class.begin.regexp']
+      expect(tokens[1]).toEqual value: '.:[', scopes: ['source.regexp.python', 'constant.other.character-class.set.regexp']
+      expect(tokens[2]).toEqual value: '\\]', scopes: ['source.regexp.python', 'constant.other.character-class.set.regexp', 'constant.character.escape.backslash.regexp']
+      expect(tokens[3]).toEqual value: '@', scopes: ['source.regexp.python', 'constant.other.character-class.set.regexp']
+      expect(tokens[4]).toEqual value: ']', scopes: ['source.regexp.python', 'constant.other.character-class.set.regexp', 'punctuation.definition.character-class.end.regexp']

--- a/spec/python-spec.coffee
+++ b/spec/python-spec.coffee
@@ -70,7 +70,7 @@ describe "Python grammar", ->
     expect(tokens[0][2].value).toBe '%d'
     expect(tokens[0][2].scopes).toEqual ['source.python', 'string.quoted.single.single-line.raw-regex.python', 'constant.other.placeholder.python']
     expect(tokens[0][3].value).toBe '['
-    expect(tokens[0][3].scopes).toEqual ['source.python', 'string.quoted.single.single-line.raw-regex.python', 'constant.other.character-class.set.regexp', 'punctuation.definition.character-class.regexp']
+    expect(tokens[0][3].scopes).toEqual ['source.python', 'string.quoted.single.single-line.raw-regex.python', 'constant.other.character-class.set.regexp', 'punctuation.definition.character-class.begin.regexp']
     expect(tokens[0][4].value).toBe "'"
     expect(tokens[0][4].scopes).toEqual ['source.python', 'string.quoted.single.single-line.raw-regex.python', 'punctuation.definition.string.end.python']
     expect(tokens[0][5].value).toBe ' '
@@ -110,7 +110,7 @@ describe "Python grammar", ->
     expect(tokens[0][2].value).toBe '%d'
     expect(tokens[0][2].scopes).toEqual ['source.python', 'string.quoted.double.single-line.raw-regex.python', 'constant.other.placeholder.python']
     expect(tokens[0][3].value).toBe '['
-    expect(tokens[0][3].scopes).toEqual ['source.python', 'string.quoted.double.single-line.raw-regex.python', 'constant.other.character-class.set.regexp', 'punctuation.definition.character-class.regexp']
+    expect(tokens[0][3].scopes).toEqual ['source.python', 'string.quoted.double.single-line.raw-regex.python', 'constant.other.character-class.set.regexp', 'punctuation.definition.character-class.begin.regexp']
     expect(tokens[0][4].value).toBe '"'
     expect(tokens[0][4].scopes).toEqual ['source.python', 'string.quoted.double.single-line.raw-regex.python', 'punctuation.definition.string.end.python']
     expect(tokens[0][5].value).toBe ' '
@@ -150,7 +150,7 @@ describe "Python grammar", ->
     expect(tokens[0][2].value).toBe '%d'
     expect(tokens[0][2].scopes).toEqual ['source.python', 'string.quoted.single.single-line.unicode-raw-regex.python', 'constant.other.placeholder.python']
     expect(tokens[0][3].value).toBe '['
-    expect(tokens[0][3].scopes).toEqual ['source.python', 'string.quoted.single.single-line.unicode-raw-regex.python', 'constant.other.character-class.set.regexp', 'punctuation.definition.character-class.regexp']
+    expect(tokens[0][3].scopes).toEqual ['source.python', 'string.quoted.single.single-line.unicode-raw-regex.python', 'constant.other.character-class.set.regexp', 'punctuation.definition.character-class.begin.regexp']
     expect(tokens[0][4].value).toBe "'"
     expect(tokens[0][4].scopes).toEqual ['source.python', 'string.quoted.single.single-line.unicode-raw-regex.python', 'punctuation.definition.string.end.python']
     expect(tokens[0][5].value).toBe ' '
@@ -190,7 +190,7 @@ describe "Python grammar", ->
     expect(tokens[0][2].value).toBe '%d'
     expect(tokens[0][2].scopes).toEqual ['source.python', 'string.quoted.double.single-line.unicode-raw-regex.python', 'constant.other.placeholder.python']
     expect(tokens[0][3].value).toBe '['
-    expect(tokens[0][3].scopes).toEqual ['source.python', 'string.quoted.double.single-line.unicode-raw-regex.python', 'constant.other.character-class.set.regexp', 'punctuation.definition.character-class.regexp']
+    expect(tokens[0][3].scopes).toEqual ['source.python', 'string.quoted.double.single-line.unicode-raw-regex.python', 'constant.other.character-class.set.regexp', 'punctuation.definition.character-class.begin.regexp']
     expect(tokens[0][4].value).toBe '"'
     expect(tokens[0][4].scopes).toEqual ['source.python', 'string.quoted.double.single-line.unicode-raw-regex.python', 'punctuation.definition.string.end.python']
     expect(tokens[0][5].value).toBe ' '


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Because there is no such thing as recursive character classes in Python.

In addition, removed the special casing of `.` from being tokenized as `constant.character.character-class.regexp` because it has no special meaning in character classes.

The edge case of having `]` as the first character in the character class is now handled correctly as a bonus.

### Alternate Designs

None.

### Benefits

Character classes with an opening square bracket inside of them will no longer break highlighting for the rest of the file.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #174