### PR TITLE
Tokenize function and parameter annotations

### DIFF
--- a/grammars/python.cson
+++ b/grammars/python.cson
@@ -279,7 +279,7 @@
                 'name': 'variable.parameter.function.python'
               '2':
                 'name': 'punctuation.separator.parameters.python'
-            'match': '\\b([a-zA-Z_][a-zA-Z_0-9]*)\\s*(?:(,)|(?=[\\n\\)]))'
+            'match': '\\b([a-zA-Z_][a-zA-Z_0-9]*)\\s*(?:(,)|\\:\\s*\\w*(,*))'
           }
         ]
       }

--- a/grammars/python.cson
+++ b/grammars/python.cson
@@ -239,13 +239,17 @@
     'beginCaptures':
       '1':
         'name': 'storage.type.function.python'
-    'end': '(\\))\\s*(?:(\\:)|(.*$\\n?))'
+    'end': '(\\))\\s*(?:(->)\\s*([A-Za-z_][A-Za-z0-9_]*)\\s*)?(?:(\\:)|(.*$\\n?))'
     'endCaptures':
       '1':
         'name': 'punctuation.definition.parameters.end.python'
       '2':
-        'name': 'punctuation.section.function.begin.python'
+        'name': 'punctuation.definition.annotation.return.python'
       '3':
+        'name': 'variable.annotation.function.python'
+      '4':
+        'name': 'punctuation.section.function.begin.python'
+      '5':
         'name': 'invalid.illegal.missing-section-begin.python'
     'name': 'meta.function.python'
     'patterns': [
@@ -278,8 +282,12 @@
               '1':
                 'name': 'variable.parameter.function.python'
               '2':
+                'name': 'punctuation.definition.annotation.parameter.python'
+              '3':
+                'name': 'variable.annotation.function.python'
+              '4':
                 'name': 'punctuation.separator.parameters.python'
-            'match': '\\b([a-zA-Z_][a-zA-Z_0-9]*)\\s*(?:(,)|\\:\\s*\\w*(,*))'
+            'match': '\\b([a-zA-Z_][a-zA-Z_0-9]*)\\s*(?:(:)\\s*([a-zA-Z_][a-zA-Z_0-9]*))?(?:(,)|(?=[\\n\\)]))'
           }
         ]
       }

--- a/grammars/python.cson
+++ b/grammars/python.cson
@@ -235,22 +235,14 @@
     ]
   }
   {
-    'begin': '^\\s*(def)\\s+(?=[A-Za-z_][A-Za-z0-9_]*\\s*\\()'
+    'begin': '^\\s*(def)\\s+(?=[A-Za-z_][\\w_]*\\s*\\()'
     'beginCaptures':
       '1':
         'name': 'storage.type.function.python'
-    'end': '(\\))\\s*(?:(->)\\s*([A-Za-z_][A-Za-z0-9_]*)\\s*)?(?:(\\:)|(.*$\\n?))'
+    'end': ':'
     'endCaptures':
-      '1':
-        'name': 'punctuation.definition.parameters.end.python'
-      '2':
-        'name': 'punctuation.definition.annotation.return.python'
-      '3':
-        'name': 'variable.other.annotation'
-      '4':
-        'name': 'punctuation.section.function.begin.python'
-      '5':
-        'name': 'invalid.illegal.missing-section-begin.python'
+      '0':
+        'name': 'punctuation.definition.function.begin.python'
     'name': 'meta.function.python'
     'patterns': [
       {
@@ -264,32 +256,64 @@
         ]
       }
       {
-        'begin': '(\\()'
+        'begin': '\\('
         'beginCaptures':
-          '1':
+          '0':
             'name': 'punctuation.definition.parameters.begin.python'
+        'end': '\\)'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.parameters.end.python'
         'contentName': 'meta.function.parameters.python'
-        'end': '(?=\\)\\s*\\:)'
         'patterns': [
           {
             'include': '#line_comments'
           }
           {
-            'include': '#keyword_arguments'
+            # param = 3
+            # param: int = 3
+            'begin': '\\b([a-zA-Z_][\\w_]*)\\s*(?:(:)\\s*([a-zA-Z_][\\w_]*))?\\s*(=)\\s*'
+            'beginCaptures':
+              '1':
+                'name': 'variable.parameter.function.python'
+              '2':
+                'name': 'punctuation.separator.python'
+              '3':
+                'name': 'storage.type.python'
+              '4':
+                'name': 'keyword.operator.assignment.python'
+            'end': '(?!\\G)'
+            'patterns': [
+              {
+                'include': '$self'
+              }
+            ]
           }
           {
+            # param
+            # param: int
+            'match': '\\b([a-zA-Z_][\\w_]*)\\s*(?:(:)\\s*([a-zA-Z_][\\w_]*))?'
             'captures':
               '1':
                 'name': 'variable.parameter.function.python'
               '2':
-                'name': 'punctuation.definition.annotation.parameter.python'
+                'name': 'punctuation.separator.python'
               '3':
-                'name': 'variable.annotation.function.python'
-              '4':
-                'name': 'punctuation.separator.parameters.python'
-            'match': '\\b([a-zA-Z_][a-zA-Z_0-9]*)\\s*(?:(:)\\s*([a-zA-Z_][a-zA-Z_0-9]*))?(?:(,)|(?=[\\n\\)]))'
+                'name': 'storage.type.python'
+          }
+          {
+            'match': ','
+            'name': 'punctuation.separator.parameters.python'
           }
         ]
+      }
+      {
+        'match': '(->)\\s*([A-Za-z_][\\w_]*)(?=\\s*:)'
+        'captures':
+          '1':
+            'name': 'keyword.operator.function-annotation.python'
+          '2':
+            'name': 'storage.type.python'
       }
     ]
   }

--- a/grammars/python.cson
+++ b/grammars/python.cson
@@ -318,12 +318,6 @@
           '2':
             'name': 'storage.type.python'
       }
-      {
-        # No match, not at the end of the line, and no opening parentheses
-        'begin': '(?!\\G)(?!\\s*$)(?!.*\\()'
-        'end': '$'
-        'name': 'invalid.illegal.missing-parameters.python'
-      }
     ]
   }
   {

--- a/grammars/python.cson
+++ b/grammars/python.cson
@@ -246,7 +246,7 @@
       '2':
         'name': 'punctuation.definition.annotation.return.python'
       '3':
-        'name': 'variable.annotation.function.python'
+        'name': 'variable.other.annotation'
       '4':
         'name': 'punctuation.section.function.begin.python'
       '5':

--- a/spec/python-spec.coffee
+++ b/spec/python-spec.coffee
@@ -729,7 +729,7 @@ describe "Python grammar", ->
     tokens = grammar.tokenizeLines('def f(a: int) -> int:')
 
     expect(tokens[0][0]).toEqual value: 'def', scopes: ['source.python', 'meta.function.python', 'storage.type.function.python']
-    expect(tokens[0][2]).toEqual value: 'f', scopes: ['source.python', 'meta.function.python', 'entity.name.function.python', 'support.function.magic.python']
+    expect(tokens[0][2]).toEqual value: 'f', scopes: ['source.python', 'meta.function.python', 'entity.name.function.python']
     expect(tokens[0][3]).toEqual value: '(', scopes: ['source.python', 'meta.function.python', 'punctuation.definition.parameters.begin.python']
     expect(tokens[1][1]).toEqual value: 'a', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'variable.parameter.function.python']
     expect(tokens[1][2]).toEqual value: ':', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'punctuation.definition.annotation.parameter.python']

--- a/spec/python-spec.coffee
+++ b/spec/python-spec.coffee
@@ -724,3 +724,17 @@ describe "Python grammar", ->
     expect(tokens[0]).toEqual value: '\'', scopes: ['source.python', 'string.quoted.single.single-line.python', 'punctuation.definition.string.begin.python']
     expect(tokens[1]).toEqual value: 'WITH example_cte AS (SELECT bar FROM foo) SELECT COUNT(*) FROM example_cte', scopes: ['source.python', 'string.quoted.single.single-line.python']
     expect(tokens[2]).toEqual value: '\'', scopes: ['source.python', 'string.quoted.single.single-line.python', 'punctuation.definition.string.end.python']
+
+  it "tokenizes a function definition with annotations", ->
+    tokens = grammar.tokenizeLines('def f(a: int) -> int:')
+
+    expect(tokens[0][0]).toEqual value: 'def', scopes: ['source.python', 'meta.function.python', 'storage.type.function.python']
+    expect(tokens[0][2]).toEqual value: 'f', scopes: ['source.python', 'meta.function.python', 'entity.name.function.python', 'support.function.magic.python']
+    expect(tokens[0][3]).toEqual value: '(', scopes: ['source.python', 'meta.function.python', 'punctuation.definition.parameters.begin.python']
+    expect(tokens[1][1]).toEqual value: 'a', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'variable.parameter.function.python']
+    expect(tokens[1][2]).toEqual value: ':', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'punctuation.definition.annotation.parameter.python']
+    expect(tokens[2][1]).toEqual value: 'int', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'variable.annotation.function.python']
+    expect(tokens[4][0]).toEqual value: ')', scopes: ['source.python', 'meta.function.python', 'punctuation.definition.parameters.end.python']
+    expect(tokens[4][0]).toEqual value: '->', scopes: ['source.python', 'meta.function.python', 'punctuation.definition.annotation.return.python']
+    expect(tokens[4][0]).toEqual value: 'int', scopes: ['source.python', 'meta.function.python', 'variable.annotation.function.python']
+    expect(tokens[4][1]).toEqual value: ':', scopes: ['source.python', 'meta.function.python', 'punctuation.section.function.begin.python']

--- a/spec/python-spec.coffee
+++ b/spec/python-spec.coffee
@@ -650,7 +650,27 @@ describe "Python grammar", ->
     expect(tokens[2][5]).toEqual value: ' comment', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'comment.line.number-sign.python']
     expect(tokens[3][1]).toEqual value: 'config', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'variable.parameter.function.python']
     expect(tokens[4][0]).toEqual value: ')', scopes: ['source.python', 'meta.function.python', 'punctuation.definition.parameters.end.python']
-    expect(tokens[4][1]).toEqual value: ':', scopes: ['source.python', 'meta.function.python', 'punctuation.section.function.begin.python']
+    expect(tokens[4][1]).toEqual value: ':', scopes: ['source.python', 'meta.function.python', 'punctuation.definition.function.begin.python']
+
+  it "tokenizes a function definition with annotations", ->
+    {tokens} = grammar.tokenizeLine 'def f(a: None, b: int = 3) -> int:'
+
+    expect(tokens[0]).toEqual value: 'def', scopes: ['source.python', 'meta.function.python', 'storage.type.function.python']
+    expect(tokens[2]).toEqual value: 'f', scopes: ['source.python', 'meta.function.python', 'entity.name.function.python']
+    expect(tokens[3]).toEqual value: '(', scopes: ['source.python', 'meta.function.python', 'punctuation.definition.parameters.begin.python']
+    expect(tokens[4]).toEqual value: 'a', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'variable.parameter.function.python']
+    expect(tokens[5]).toEqual value: ':', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'punctuation.separator.python']
+    expect(tokens[7]).toEqual value: 'None', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'storage.type.python']
+    expect(tokens[8]).toEqual value: ',', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'punctuation.separator.parameters.python']
+    expect(tokens[10]).toEqual value: 'b', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'variable.parameter.function.python']
+    expect(tokens[11]).toEqual value: ':', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'punctuation.separator.python']
+    expect(tokens[13]).toEqual value: 'int', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'storage.type.python']
+    expect(tokens[15]).toEqual value: '=', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'keyword.operator.assignment.python']
+    expect(tokens[17]).toEqual value: '3', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'constant.numeric.integer.decimal.python']
+    expect(tokens[18]).toEqual value: ')', scopes: ['source.python', 'meta.function.python', 'punctuation.definition.parameters.end.python']
+    expect(tokens[20]).toEqual value: '->', scopes: ['source.python', 'meta.function.python', 'keyword.operator.function-annotation.python']
+    expect(tokens[22]).toEqual value: 'int', scopes: ['source.python', 'meta.function.python', 'storage.type.python']
+    expect(tokens[23]).toEqual value: ':', scopes: ['source.python', 'meta.function.python', 'punctuation.definition.function.begin.python']
 
   it "tokenizes complex function calls", ->
     {tokens} = grammar.tokenizeLine "torch.nn.BCELoss()(Variable(bayes_optimal_prob, 1, requires_grad=False), Yvar).data[0]"
@@ -718,23 +738,8 @@ describe "Python grammar", ->
       expect(tokens[9][0]).toEqual value: delim, scopes: ['source.python', scope, 'punctuation.definition.string.end.python']
 
   it "tokenizes SQL inline highlighting on single line with a CTE", ->
-
     {tokens} = grammar.tokenizeLine('\'WITH example_cte AS (SELECT bar FROM foo) SELECT COUNT(*) FROM example_cte\'')
 
     expect(tokens[0]).toEqual value: '\'', scopes: ['source.python', 'string.quoted.single.single-line.python', 'punctuation.definition.string.begin.python']
     expect(tokens[1]).toEqual value: 'WITH example_cte AS (SELECT bar FROM foo) SELECT COUNT(*) FROM example_cte', scopes: ['source.python', 'string.quoted.single.single-line.python']
     expect(tokens[2]).toEqual value: '\'', scopes: ['source.python', 'string.quoted.single.single-line.python', 'punctuation.definition.string.end.python']
-
-  it "tokenizes a function definition with annotations", ->
-    tokens = grammar.tokenizeLines('def f(a: int) -> int:')
-
-    expect(tokens[0][0]).toEqual value: 'def', scopes: ['source.python', 'meta.function.python', 'storage.type.function.python']
-    expect(tokens[0][2]).toEqual value: 'f', scopes: ['source.python', 'meta.function.python', 'entity.name.function.python']
-    expect(tokens[0][3]).toEqual value: '(', scopes: ['source.python', 'meta.function.python', 'punctuation.definition.parameters.begin.python']
-    expect(tokens[1][1]).toEqual value: 'a', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'variable.parameter.function.python']
-    expect(tokens[1][2]).toEqual value: ':', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'punctuation.definition.annotation.parameter.python']
-    expect(tokens[2][1]).toEqual value: 'int', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'variable.annotation.function.python']
-    expect(tokens[4][0]).toEqual value: ')', scopes: ['source.python', 'meta.function.python', 'punctuation.definition.parameters.end.python']
-    expect(tokens[4][0]).toEqual value: '->', scopes: ['source.python', 'meta.function.python', 'punctuation.definition.annotation.return.python']
-    expect(tokens[4][0]).toEqual value: 'int', scopes: ['source.python', 'meta.function.python', 'variable.annotation.function.python']
-    expect(tokens[4][1]).toEqual value: ':', scopes: ['source.python', 'meta.function.python', 'punctuation.section.function.begin.python']

--- a/spec/python-spec.coffee
+++ b/spec/python-spec.coffee
@@ -634,19 +634,6 @@ describe "Python grammar", ->
     expect(tokens[2]).toEqual value: 'def', scopes: ['source.python', 'meta.function.python', 'storage.type.function.python']
     expect(tokens[4]).toEqual value: 'test', scopes: ['source.python', 'meta.function.python', 'entity.name.function.python']
 
-  it "tokenizes functions that are missing parameters", ->
-    {tokens} = grammar.tokenizeLine 'def test # whoops'
-
-    expect(tokens[0]).toEqual value: 'def', scopes: ['source.python', 'meta.function.python', 'storage.type.function.python']
-    expect(tokens[2]).toEqual value: 'test', scopes: ['source.python', 'meta.function.python', 'entity.name.function.python']
-    expect(tokens[3]).toEqual value: ' # whoops', scopes: ['source.python', 'meta.function.python', 'invalid.illegal.missing-parameters.python']
-
-    {tokens} = grammar.tokenizeLine 'def test:'
-
-    expect(tokens[0]).toEqual value: 'def', scopes: ['source.python', 'meta.function.python', 'storage.type.function.python']
-    expect(tokens[2]).toEqual value: 'test', scopes: ['source.python', 'meta.function.python', 'entity.name.function.python']
-    expect(tokens[3]).toEqual value: ':', scopes: ['source.python', 'meta.function.python', 'invalid.illegal.missing-parameters.python']
-
   it "tokenizes comments inside function parameters", ->
     {tokens} = grammar.tokenizeLine('def test(arg, # comment')
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Tokenizes optional function and parameter annotations in accordance with [PEP-3107](https://www.python.org/dev/peps/pep-3107/).

### Alternate Designs

I looked at the three prior attempts.
#84 did not add support for function return-value annotations
#88 did not add highlighting for annotations
#95 when I was testing it didn't appear to support function return-value annotations

### Benefits

Fully supports PEP-3107, which has been in effect since Python 3.0 was released.

### Possible Drawbacks

This PR does include some minor relaxations in function definition syntax in order to more easily accommodate annotations.  These changes also don't apply at all to Python 2 files.

### Applicable Issues

Fixes #68
Supersedes and closes #84
Supersedes and closes #88
Supersedes and closes #95

@corylation @berdario @pchaigno many thanks for your PRs.

@corylation @berdario @pchaigno @MaximSokolov I'd like to merge this soon (probably by Tuesday/Wednesday), but if you have any issues with the scope names I'm using please tell me!