### PR TITLE
Tokenize `yield from`

### DIFF
--- a/grammars/python.cson
+++ b/grammars/python.cson
@@ -108,7 +108,7 @@
   {
     'comment': 'keywords that alter flow from within a block'
     'name': 'keyword.control.statement.python'
-    'match': '\\b(with|break|continue|pass|return|yield|await)\\b'
+    'match': '\\b(with|break|continue|pass|return|yield(\\s+from)?|await)\\b'
   }
   {
     'comment': 'keyword operators that evaluate to True or False'

--- a/spec/python-spec.coffee
+++ b/spec/python-spec.coffee
@@ -16,6 +16,16 @@ describe "Python grammar", ->
     expect(grammar).toBeDefined()
     expect(grammar.scopeName).toBe "source.python"
 
+  it "tokenizes `yield`", ->
+    {tokens} = grammar.tokenizeLine 'yield v'
+
+    expect(tokens[0]).toEqual value: 'yield', scopes: ['source.python', 'keyword.control.statement.python']
+
+  it "tokenizes `yield from`", ->
+    {tokens} = grammar.tokenizeLine 'yield from v'
+
+    expect(tokens[0]).toEqual value: 'yield from', scopes: ['source.python', 'keyword.control.statement.python']
+
   it "tokenizes multi-line strings", ->
     tokens = grammar.tokenizeLines('"1\\\n2"')
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Tokenizes `yield from` as described in [PEP-380](https://www.python.org/dev/peps/pep-0380/).

### Alternate Designs

None.

### Benefits

`yield from` will be tokenized as one expression instead of two (`yield` + `from` as in `import from`).

### Possible Drawbacks

None.

### Applicable Issues

Fixes #119