### PR TITLE
Improve lambda tokenization

### DIFF
--- a/grammars/python.cson
+++ b/grammars/python.cson
@@ -312,35 +312,42 @@
     ]
   }
   {
-    'begin': '(lambda)(?=\\s+)'
+    'begin': '(lambda)\\s+'
     'beginCaptures':
       '1':
         'name': 'storage.type.function.inline.python'
-    'end': '(\\:)'
+    'end': ':'
     'endCaptures':
-      '1':
-        'name': 'punctuation.definition.parameters.end.python'
-      '2':
-        'name': 'punctuation.section.function.begin.python'
-      '3':
-        'name': 'invalid.illegal.missing-section-begin.python'
+      '0':
+        'name': 'punctuation.definition.function.begin.python'
     'name': 'meta.function.inline.python'
     'patterns': [
       {
-        'begin': '\\s+'
-        'contentName': 'meta.function.inline.parameters.python'
+        'begin': '\\G'
         'end': '(?=\\:)'
+        'contentName': 'meta.function.inline.parameters.python'
         'patterns': [
           {
-            'include': '#keyword_arguments'
-          }
-          {
-            'captures':
+            'begin': '\\b([a-zA-Z_][\\w_]*)\\s*(=)\\s*'
+            'beginCaptures':
               '1':
                 'name': 'variable.parameter.function.python'
               '2':
-                'name': 'punctuation.separator.parameters.python'
-            'match': '\\b([a-zA-Z_][a-zA-Z_0-9]*)\\s*(?:(,)|(?=[\\n\\)\\:]))'
+                'name': 'keyword.operator.assignment.python'
+            'end': '(?!\\G)'
+            'patterns': [
+              {
+                'include': '$self'
+              }
+            ]
+          }
+          {
+            'match': '\\b([a-zA-Z_][\\w_]*)\\b'
+            'name': 'variable.parameter.function.python'
+          }
+          {
+            'match': ','
+            'name': 'punctuation.separator.parameters.python'
           }
         ]
       }
@@ -480,12 +487,6 @@
         'include': '$self'
       }
     ]
-  }
-  {
-    'captures':
-      '1':
-        'name': 'storage.type.function.python'
-    'match': '\\b(def|lambda)\\b'
   }
   {
     'captures':

--- a/grammars/python.cson
+++ b/grammars/python.cson
@@ -328,6 +328,7 @@
         'contentName': 'meta.function.inline.parameters.python'
         'patterns': [
           {
+            # param = 3
             'begin': '\\b([a-zA-Z_][\\w_]*)\\s*(=)\\s*'
             'beginCaptures':
               '1':
@@ -342,6 +343,7 @@
             ]
           }
           {
+            # param
             'match': '\\b([a-zA-Z_][\\w_]*)\\b'
             'name': 'variable.parameter.function.python'
           }

--- a/spec/python-spec.coffee
+++ b/spec/python-spec.coffee
@@ -679,6 +679,19 @@ describe "Python grammar", ->
     expect(tokens[20]).toEqual value: ')', scopes: ['source.python', 'meta.function-call.python', 'punctuation.definition.arguments.end.python']
     expect(tokens[21]).toEqual value: '.', scopes: ['source.python']
 
+  it "tokenizes lambdas", ->
+    {tokens} = grammar.tokenizeLine "lambda x, z = 4: x * z"
+
+    expect(tokens[0]).toEqual value: 'lambda', scopes: ['source.python', 'meta.function.inline.python', 'storage.type.function.inline.python']
+    expect(tokens[1]).toEqual value: ' ', scopes: ['source.python', 'meta.function.inline.python']
+    expect(tokens[2]).toEqual value: 'x', scopes: ['source.python', 'meta.function.inline.python', 'meta.function.inline.parameters.python', 'variable.parameter.function.python']
+    expect(tokens[3]).toEqual value: ',', scopes: ['source.python', 'meta.function.inline.python', 'meta.function.inline.parameters.python', 'punctuation.separator.parameters.python']
+    expect(tokens[5]).toEqual value: 'z', scopes: ['source.python', 'meta.function.inline.python', 'meta.function.inline.parameters.python', 'variable.parameter.function.python']
+    expect(tokens[7]).toEqual value: '=', scopes: ['source.python', 'meta.function.inline.python', 'meta.function.inline.parameters.python', 'keyword.operator.assignment.python']
+    expect(tokens[9]).toEqual value: '4', scopes: ['source.python', 'meta.function.inline.python', 'meta.function.inline.parameters.python', 'constant.numeric.integer.decimal.python']
+    expect(tokens[10]).toEqual value: ':', scopes: ['source.python', 'meta.function.inline.python', 'punctuation.definition.function.begin.python']
+    expect(tokens[11]).toEqual value: ' ', scopes: ['source.python']
+
   it "tokenizes SQL inline highlighting on blocks", ->
     delimsByScope =
       "string.quoted.double.block.sql.python": '"""'


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This PR fixes a few deficiencies regarding lambda tokenization, such as:
* The colon marking the start of the function was incorrectly tokenized as `punctuation.definition.parameters.end.python`, most likely because the `endCaptures` block was copy/pasted from the function pattern.
* Hard-to-read (and incorrect!) parameter matching, again most likely copied from functions.

### Alternate Designs

None.

### Benefits

Better lambda highlighting.

### Possible Drawbacks

None.

### Applicable Issues

None.