### PR TITLE
Tokenize async function definitions

### DIFF
--- a/grammars/python.cson
+++ b/grammars/python.cson
@@ -236,9 +236,11 @@
     ]
   }
   {
-    'begin': '^\\s*(def)\\s+(?=[A-Za-z_][A-Za-z0-9_]*\\s*\\()'
+    'begin': '^\\s*(?:(async)\\s+)?(def)\\s+(?=[A-Za-z_][A-Za-z0-9_]*)'
     'beginCaptures':
       '1':
+        'name': 'storage.modifier.async.python'
+      '2':
         'name': 'storage.type.function.python'
     'end': '(\\))\\s*(?:(\\:)|(.*$\\n?))'
     'endCaptures':
@@ -284,30 +286,11 @@
           }
         ]
       }
-    ]
-  }
-  {
-    'begin': '^\\s*(def)\\s+(?=[A-Za-z_][A-Za-z0-9_]*)'
-    'beginCaptures':
-      '1':
-        'name': 'storage.type.function.python'
-    'end': '(\\()|\\s*($\\n?|#.*$\\n?)'
-    'endCaptures':
-      '1':
-        'name': 'punctuation.definition.parameters.begin.python'
-      '2':
-        'name': 'invalid.illegal.missing-parameters.python'
-    'name': 'meta.function.python'
-    'patterns': [
       {
-        'begin': '(?=[A-Za-z_][A-Za-z0-9_]*)'
-        'contentName': 'entity.name.function.python'
-        'end': '(?![A-Za-z0-9_])'
-        'patterns': [
-          {
-            'include': '#entity_name_function'
-          }
-        ]
+        # No match, not at the end of the line, and no opening parentheses
+        'begin': '(?!\\G)(?!\\s*$)(?!.*\\()'
+        'end': '$'
+        'name': 'invalid.illegal.missing-parameters.python'
       }
     ]
   }

--- a/spec/python-spec.coffee
+++ b/spec/python-spec.coffee
@@ -630,6 +630,27 @@ describe "Python grammar", ->
     expect(tokens[0][2].value).toBe 'foo'
     expect(tokens[0][2].scopes).toEqual ['source.python']
 
+  it "tokenizes async function definitions", ->
+    {tokens} = grammar.tokenizeLine 'async def test(param):'
+
+    expect(tokens[0]).toEqual value: 'async', scopes: ['source.python', 'meta.function.python', 'storage.modifier.async.python']
+    expect(tokens[1]).toEqual value: ' ', scopes: ['source.python', 'meta.function.python']
+    expect(tokens[2]).toEqual value: 'def', scopes: ['source.python', 'meta.function.python', 'storage.type.function.python']
+    expect(tokens[4]).toEqual value: 'test', scopes: ['source.python', 'meta.function.python', 'entity.name.function.python']
+
+  it "tokenizes functions that are missing parameters", ->
+    {tokens} = grammar.tokenizeLine 'def test # whoops'
+
+    expect(tokens[0]).toEqual value: 'def', scopes: ['source.python', 'meta.function.python', 'storage.type.function.python']
+    expect(tokens[2]).toEqual value: 'test', scopes: ['source.python', 'meta.function.python', 'entity.name.function.python']
+    expect(tokens[3]).toEqual value: ' # whoops', scopes: ['source.python', 'meta.function.python', 'invalid.illegal.missing-parameters.python']
+
+    {tokens} = grammar.tokenizeLine 'def test:'
+
+    expect(tokens[0]).toEqual value: 'def', scopes: ['source.python', 'meta.function.python', 'storage.type.function.python']
+    expect(tokens[2]).toEqual value: 'test', scopes: ['source.python', 'meta.function.python', 'entity.name.function.python']
+    expect(tokens[3]).toEqual value: ':', scopes: ['source.python', 'meta.function.python', 'invalid.illegal.missing-parameters.python']
+
   it "tokenizes comments inside function parameters", ->
     {tokens} = grammar.tokenizeLine('def test(arg, # comment')
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

There are two main changes in this PR.
1. Support async function definitions, `async def test(params):` as per [PEP-492](https://www.python.org/dev/peps/pep-0492/).  `async` is tokenized as `storage.modifier.async.python`, similarly to JavaScript.
2. Instead of having two function definition patterns, one for the full form and one for when the parameters list is missing, I have consolidated both patterns into one while retaining the invalid highlighting.  You can see an example of how this works in the specs.

### Alternate Designs

None.

### Benefits

I believe this is the last part of PEP-492 that has not yet been implemented by language-python.  In addition, maintaining the function patterns will be easier now that there is only one pattern instead of two.

### Possible Drawbacks

Possible mistakes in incorporating the missing parameters highlighting into the existing pattern.

### Applicable Issues

Fixes #93