### PR TITLE
Improve tokenization

### DIFF
--- a/grammars/python.cson
+++ b/grammars/python.cson
@@ -24,6 +24,9 @@
     'include': '#line_comments'
   }
   {
+    'include': '#language_variables'
+  }
+  {
     'match': '\\b(?i:(0x\\h*)L)'
     'name': 'constant.numeric.integer.long.hexadecimal.python'
   }
@@ -505,9 +508,6 @@
     'include': '#string_quoted_double'
   }
   {
-    'include': '#language_variables'
-  }
-  {
     'begin': '(\\()'
     'end': '(\\))'
     'patterns': [
@@ -672,6 +672,10 @@
         'patterns': [
           {
             'include': '#keyword_arguments'
+          }
+          {
+            'match': ','
+            'name': 'punctuation.separator.arguments.python'
           }
           {
             'include': '$self'
@@ -899,6 +903,10 @@
         'patterns': [
           {
             'include': '#keyword_arguments'
+          }
+          {
+            'match': ','
+            'name': 'punctuation.separator.arguments.python'
           }
           {
             'include': '$self'

--- a/grammars/python.cson
+++ b/grammars/python.cson
@@ -399,58 +399,10 @@
     ]
   }
   {
-    'begin': '(?:([A-Za-z_][A-Za-z0-9_]*)|(?<=\\)|\\]))\\s*(\\()'
-    'beginCaptures':
-      '1':
-        'patterns': [
-          {
-            'include': '#function_names'
-          }
-        ]
-      '2':
-        'name': 'punctuation.definition.arguments.begin.bracket.round.python'
-    'end': '\\)'
-    'endCaptures':
-      '0':
-        'name': 'punctuation.definition.arguments.end.bracket.round.python'
-    'name': 'meta.function-call.python'
-    'contentName': 'meta.function-call.arguments.python'
-    'patterns': [
-      {
-        'include': '#keyword_arguments'
-      }
-      {
-        'include': '$self'
-      }
-    ]
+    'include': '#function_calls'
   }
   {
-    'begin': '(\\.)([a-zA-Z_][a-zA-Z0-9_]*)\\s*(\\()'
-    'beginCaptures':
-      '1':
-        'name': 'punctuation.separator.method.period.python'
-      '2':
-        'patterns': [
-          {
-            'include': '#function_names'
-          }
-        ]
-      '3':
-        'name': 'punctuation.definition.arguments.begin.bracket.round.python'
-    'end': '\\)'
-    'endCaptures':
-      '0':
-        'name': 'punctuation.definition.arguments.end.bracket.round.python'
-    'name': 'meta.method-call.python'
-    'contentName': 'meta.method-call.arguments.python'
-    'patterns': [
-      {
-        'include': '#keyword_arguments'
-      }
-      {
-        'include': '$self'
-      }
-    ]
+    'include': '#method_calls'
   }
   {
     'include': '#objects'
@@ -665,6 +617,35 @@
         'patterns': [
           {
             'include': '#string_quoted_single'
+          }
+        ]
+      }
+    ]
+  'function_calls':
+    'patterns': [
+      {
+        'begin': '(?:([A-Za-z_][A-Za-z0-9_]*)|(?<=\\)|\\]))\\s*(\\()'
+        'beginCaptures':
+          '1':
+            'patterns': [
+              {
+                'include': '#function_names'
+              }
+            ]
+          '2':
+            'name': 'punctuation.definition.arguments.begin.bracket.round.python'
+        'end': '\\)'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.arguments.end.bracket.round.python'
+        'name': 'meta.function-call.python'
+        'contentName': 'meta.function-call.arguments.python'
+        'patterns': [
+          {
+            'include': '#keyword_arguments'
+          }
+          {
+            'include': '$self'
           }
         ]
       }
@@ -889,6 +870,37 @@
     'comment': 'magic variables which a class/module may have.'
     'match': '\\b__(all|annotations|bases|class|closure|code|debug|dict|doc|file|func|globals|kwdefaults|members|metaclass|methods|module|name|qualname|self|slots|weakref)__\\b'
     'name': 'support.variable.magic.python'
+  'method_calls':
+    'patterns': [
+      {
+        'begin': '(\\.)([a-zA-Z_][a-zA-Z0-9_]*)\\s*(\\()'
+        'beginCaptures':
+          '1':
+            'name': 'punctuation.separator.method.period.python'
+          '2':
+            'patterns': [
+              {
+                'include': '#function_names'
+              }
+            ]
+          '3':
+            'name': 'punctuation.definition.arguments.begin.bracket.round.python'
+        'end': '\\)'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.arguments.end.bracket.round.python'
+        'name': 'meta.method-call.python'
+        'contentName': 'meta.method-call.arguments.python'
+        'patterns': [
+          {
+            'include': '#keyword_arguments'
+          }
+          {
+            'include': '$self'
+          }
+        ]
+      }
+    ]
   'objects':
     'patterns': [
       {

--- a/grammars/python.cson
+++ b/grammars/python.cson
@@ -629,6 +629,9 @@
           '1':
             'patterns': [
               {
+                'include': '#builtin_functions'
+              }
+              {
                 'include': '#function_names'
               }
             ]
@@ -648,38 +651,6 @@
             'include': '$self'
           }
         ]
-      }
-    ]
-  'function_names':
-    'patterns': [
-      {
-        'include': '#magic_function_names'
-      }
-      {
-        'include': '#magic_variable_names'
-      }
-      {
-        'include': '#illegal_names'
-      }
-      {
-        'match': '[a-zA-Z_][a-zA-Z0-9_]*'
-        'name': 'entity.name.function.python'
-      }
-    ]
-  'line_comments':
-    'begin': '(^[ \\t]+)?(?=#)'
-    'beginCaptures':
-      '1':
-        'name': 'punctuation.whitespace.comment.leading.python'
-    'end': '(?!\\G)'
-    'patterns': [
-      {
-        'begin': '#'
-        'beginCaptures':
-          '0':
-            'name': 'punctuation.definition.comment.python'
-        'end': '\\n'
-        'name': 'comment.line.number-sign.python'
       }
     ]
   'dotted_name':
@@ -810,25 +781,17 @@
       '3':
         'name': 'constant.character.escape.unicode.name.python'
     'match': '(\\\\U[0-9A-Fa-f]{8})|(\\\\u[0-9A-Fa-f]{4})|(\\\\N\\{[a-zA-Z ]+\\})'
-  'function_name':
+  'function_names':
     'patterns': [
       {
         'include': '#magic_function_names'
       }
       {
-        'include': '#magic_variable_names'
+        'include': '#illegal_names'
       }
       {
-        'include': '#builtin_exceptions'
-      }
-      {
-        'include': '#builtin_functions'
-      }
-      {
-        'include': '#builtin_types'
-      }
-      {
-        'include': '#generic_names'
+        'match': '[a-zA-Z_][a-zA-Z0-9_]*'
+        'name': 'entity.name.function.python'
       }
     ]
   'generic_names':
@@ -855,6 +818,22 @@
   'language_variables':
     'match': '\\b(self|cls)\\b'
     'name': 'variable.language.self.python'
+  'line_comments':
+    'begin': '(^[ \\t]+)?(?=#)'
+    'beginCaptures':
+      '1':
+        'name': 'punctuation.whitespace.comment.leading.python'
+    'end': '(?!\\G)'
+    'patterns': [
+      {
+        'begin': '#'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.comment.python'
+        'end': '\\n'
+        'name': 'comment.line.number-sign.python'
+      }
+    ]
   'line_continuation':
     'captures':
       '1':

--- a/grammars/python.cson
+++ b/grammars/python.cson
@@ -453,6 +453,12 @@
     ]
   }
   {
+    'include': '#objects'
+  }
+  {
+    'include': '#properties'
+  }
+  {
     'begin': '(?=[A-Za-z_][A-Za-z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z_0-9]*)*\\s*\\[)'
     'end': '(\\])'
     'endCaptures':
@@ -883,6 +889,67 @@
     'comment': 'magic variables which a class/module may have.'
     'match': '\\b__(all|annotations|bases|class|closure|code|debug|dict|doc|file|func|globals|kwdefaults|members|metaclass|methods|module|name|qualname|self|slots|weakref)__\\b'
     'name': 'support.variable.magic.python'
+  'objects':
+    'patterns': [
+      {
+        # OBJ in OBJ.prop, OBJ.methodCall()
+        'match': '[A-Z][A-Z0-9_]*(?=\\s*\\.\\s*[a-zA-Z_][a-zA-Z0-9_]*)'
+        'name': 'constant.other.object.python'
+      }
+      {
+        # obj in obj.prop, obj.methodCall()
+        'match': '[a-zA-Z_][a-zA-Z0-9_]*(?=\\s*\\.\\s*[a-zA-Z_][a-zA-Z0-9_]*)'
+        'name': 'variable.other.object.python'
+      }
+    ]
+  'properties':
+    'patterns': [
+      {
+        # PROP1 in obj.PROP1.prop2, func().PROP1.prop2
+        'match': '(\\.)\\s*([A-Z][A-Z0-9_]*\\b\\$*)(?=\\s*\\.\\s*[a-zA-Z_][a-zA-Z0-9_]*)'
+        'captures':
+          '1':
+            'name': 'punctuation.separator.property.period.python'
+          '2':
+            'name': 'constant.other.object.property.python'
+      }
+      {
+        # prop1 in obj.prop1.prop2, func().prop1.prop2
+        'match': '(\\.)\\s*(\\$*[a-zA-Z_][a-zA-Z0-9_]*)(?=\\s*\\.\\s*[a-zA-Z_][a-zA-Z0-9_]*)'
+        'captures':
+          '1':
+            'name': 'punctuation.separator.property.period.python'
+          '2':
+            'name': 'variable.other.object.property.python'
+      }
+      {
+        # PROP in obj.PROP, func().PROP
+        'match': '(\\.)\\s*([A-Z][A-Z0-9_$]*\\b\\$*)'
+        'captures':
+          '1':
+            'name': 'punctuation.separator.property.period.python'
+          '2':
+            'name': 'constant.other.property.python'
+      }
+      {
+        # prop in obj.prop, func().prop
+        'match': '(\\.)\\s*(\\$*[a-zA-Z_][a-zA-Z0-9_]*)'
+        'captures':
+          '1':
+            'name': 'punctuation.separator.property.period.python'
+          '2':
+            'name': 'variable.other.property.python'
+      }
+      {
+        # 123illegal in obj.123illegal, func().123illegal
+        'match': '(\\.)\\s*([0-9][a-zA-Z0-9_]*)'
+        'captures':
+          '1':
+            'name': 'punctuation.separator.property.period.python'
+          '2':
+            'name': 'invalid.illegal.identifier.python'
+      }
+    ]
   'nested_replacement_field':
     'match': '''(?x)
       {

--- a/grammars/python.cson
+++ b/grammars/python.cson
@@ -399,22 +399,50 @@
     ]
   }
   {
-    'begin': '(?:([A-Za-z_][A-Za-z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z_0-9]*)*)|(?<=\\)|\\]))\\s*(\\()'
+    'begin': '(?:([A-Za-z_][A-Za-z0-9_]*)|(?<=\\)|\\]))\\s*(\\()'
     'beginCaptures':
       '1':
         'patterns': [
           {
-            'include': '#dotted_name'
+            'include': '#function_names'
           }
         ]
       '2':
-        'name': 'punctuation.definition.arguments.begin.python'
+        'name': 'punctuation.definition.arguments.begin.bracket.round.python'
     'end': '\\)'
     'endCaptures':
       '0':
-        'name': 'punctuation.definition.arguments.end.python'
+        'name': 'punctuation.definition.arguments.end.bracket.round.python'
     'name': 'meta.function-call.python'
     'contentName': 'meta.function-call.arguments.python'
+    'patterns': [
+      {
+        'include': '#keyword_arguments'
+      }
+      {
+        'include': '$self'
+      }
+    ]
+  }
+  {
+    'begin': '(\\.)([a-zA-Z_][a-zA-Z0-9_]*)\\s*(\\()'
+    'beginCaptures':
+      '1':
+        'name': 'punctuation.separator.method.period.python'
+      '2':
+        'patterns': [
+          {
+            'include': '#function_names'
+          }
+        ]
+      '3':
+        'name': 'punctuation.definition.arguments.begin.bracket.round.python'
+    'end': '\\)'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.arguments.end.bracket.round.python'
+    'name': 'meta.method-call.python'
+    'contentName': 'meta.method-call.arguments.python'
     'patterns': [
       {
         'include': '#keyword_arguments'
@@ -491,9 +519,6 @@
   }
   {
     'include': '#string_quoted_double'
-  }
-  {
-    'include': '#dotted_name'
   }
   {
     'include': '#language_variables'
@@ -636,6 +661,22 @@
             'include': '#string_quoted_single'
           }
         ]
+      }
+    ]
+  'function_names':
+    'patterns': [
+      {
+        'include': '#magic_function_names'
+      }
+      {
+        'include': '#magic_variable_names'
+      }
+      {
+        'include': '#illegal_names'
+      }
+      {
+        'match': '[a-zA-Z_][a-zA-Z0-9_]*'
+        'name': 'entity.name.function.python'
       }
     ]
   'line_comments':

--- a/spec/python-spec.coffee
+++ b/spec/python-spec.coffee
@@ -307,18 +307,18 @@ describe "Python grammar", ->
         {tokens} = grammar.tokenizeLine "f'{name.decode(\"utf-8\").lower()}'"
 
         expect(tokens[2]).toEqual value: '{', scopes: ['source.python', "string.quoted.single.single-line.format.python", 'meta.interpolation.python', 'punctuation.definition.interpolation.begin.bracket.curly.python']
-        expect(tokens[3]).toEqual value: 'name', scopes: ['source.python', "string.quoted.single.single-line.format.python", 'meta.interpolation.python', 'meta.embedded.python', 'meta.function-call.python']
-        expect(tokens[4]).toEqual value: '.', scopes: ['source.python', "string.quoted.single.single-line.format.python", 'meta.interpolation.python', 'meta.embedded.python', 'meta.function-call.python']
-        expect(tokens[5]).toEqual value: 'decode', scopes: ['source.python', "string.quoted.single.single-line.format.python", 'meta.interpolation.python', 'meta.embedded.python', 'meta.function-call.python']
-        expect(tokens[6]).toEqual value: '(', scopes: ['source.python', "string.quoted.single.single-line.format.python", 'meta.interpolation.python', 'meta.embedded.python', 'meta.function-call.python', 'punctuation.definition.arguments.begin.python']
-        expect(tokens[7]).toEqual value: '"', scopes: ['source.python', "string.quoted.single.single-line.format.python", 'meta.interpolation.python', 'meta.embedded.python', 'meta.function-call.python', 'meta.function-call.arguments.python', "string.quoted.double.single-line.python", 'punctuation.definition.string.begin.python']
-        expect(tokens[8]).toEqual value: 'utf-8', scopes: ['source.python', "string.quoted.single.single-line.format.python", 'meta.interpolation.python', 'meta.embedded.python', 'meta.function-call.python', 'meta.function-call.arguments.python', "string.quoted.double.single-line.python"]
-        expect(tokens[9]).toEqual value: '"', scopes: ['source.python', "string.quoted.single.single-line.format.python", 'meta.interpolation.python', 'meta.embedded.python', 'meta.function-call.python', 'meta.function-call.arguments.python', "string.quoted.double.single-line.python", 'punctuation.definition.string.end.python']
-        expect(tokens[10]).toEqual value: ')', scopes: ['source.python', "string.quoted.single.single-line.format.python", 'meta.interpolation.python', 'meta.embedded.python', 'meta.function-call.python', 'punctuation.definition.arguments.end.python']
-        expect(tokens[11]).toEqual value: '.', scopes: ['source.python', "string.quoted.single.single-line.format.python", 'meta.interpolation.python', 'meta.embedded.python']
-        expect(tokens[12]).toEqual value: 'lower', scopes: ['source.python', "string.quoted.single.single-line.format.python", 'meta.interpolation.python', 'meta.embedded.python', 'meta.function-call.python']
-        expect(tokens[13]).toEqual value: '(', scopes: ['source.python', "string.quoted.single.single-line.format.python", 'meta.interpolation.python', 'meta.embedded.python', 'meta.function-call.python', 'punctuation.definition.arguments.begin.python']
-        expect(tokens[14]).toEqual value: ')', scopes: ['source.python', "string.quoted.single.single-line.format.python", 'meta.interpolation.python', 'meta.embedded.python', 'meta.function-call.python', 'punctuation.definition.arguments.end.python']
+        expect(tokens[3]).toEqual value: 'name', scopes: ['source.python', "string.quoted.single.single-line.format.python", 'meta.interpolation.python', 'meta.embedded.python', 'variable.other.object.python']
+        expect(tokens[4]).toEqual value: '.', scopes: ['source.python', "string.quoted.single.single-line.format.python", 'meta.interpolation.python', 'meta.embedded.python', 'meta.method-call.python', 'punctuation.separator.method.period.python']
+        expect(tokens[5]).toEqual value: 'decode', scopes: ['source.python', "string.quoted.single.single-line.format.python", 'meta.interpolation.python', 'meta.embedded.python', 'meta.method-call.python', 'entity.name.function.python']
+        expect(tokens[6]).toEqual value: '(', scopes: ['source.python', "string.quoted.single.single-line.format.python", 'meta.interpolation.python', 'meta.embedded.python', 'meta.method-call.python', 'punctuation.definition.arguments.begin.bracket.round.python']
+        expect(tokens[7]).toEqual value: '"', scopes: ['source.python', "string.quoted.single.single-line.format.python", 'meta.interpolation.python', 'meta.embedded.python', 'meta.method-call.python', 'meta.method-call.arguments.python', "string.quoted.double.single-line.python", 'punctuation.definition.string.begin.python']
+        expect(tokens[8]).toEqual value: 'utf-8', scopes: ['source.python', "string.quoted.single.single-line.format.python", 'meta.interpolation.python', 'meta.embedded.python', 'meta.method-call.python', 'meta.method-call.arguments.python', "string.quoted.double.single-line.python"]
+        expect(tokens[9]).toEqual value: '"', scopes: ['source.python', "string.quoted.single.single-line.format.python", 'meta.interpolation.python', 'meta.embedded.python', 'meta.method-call.python', 'meta.method-call.arguments.python', "string.quoted.double.single-line.python", 'punctuation.definition.string.end.python']
+        expect(tokens[10]).toEqual value: ')', scopes: ['source.python', "string.quoted.single.single-line.format.python", 'meta.interpolation.python', 'meta.embedded.python', 'meta.method-call.python', 'punctuation.definition.arguments.end.bracket.round.python']
+        expect(tokens[11]).toEqual value: '.', scopes: ['source.python', "string.quoted.single.single-line.format.python", 'meta.interpolation.python', 'meta.embedded.python', 'meta.method-call.python', 'punctuation.separator.method.period.python']
+        expect(tokens[12]).toEqual value: 'lower', scopes: ['source.python', "string.quoted.single.single-line.format.python", 'meta.interpolation.python', 'meta.embedded.python', 'meta.method-call.python', 'entity.name.function.python']
+        expect(tokens[13]).toEqual value: '(', scopes: ['source.python', "string.quoted.single.single-line.format.python", 'meta.interpolation.python', 'meta.embedded.python', 'meta.method-call.python', 'punctuation.definition.arguments.begin.bracket.round.python']
+        expect(tokens[14]).toEqual value: ')', scopes: ['source.python', "string.quoted.single.single-line.format.python", 'meta.interpolation.python', 'meta.embedded.python', 'meta.method-call.python', 'punctuation.definition.arguments.end.bracket.round.python']
         expect(tokens[15]).toEqual value: '}', scopes: ['source.python', "string.quoted.single.single-line.format.python", 'meta.interpolation.python', 'punctuation.definition.interpolation.end.bracket.curly.python']
 
       it "tokenizes conversion flags", ->
@@ -599,32 +599,23 @@ describe "Python grammar", ->
   it "tokenizes properties of self as self-type variables", ->
     tokens = grammar.tokenizeLines('self.foo')
 
-    expect(tokens[0][0].value).toBe 'self'
-    expect(tokens[0][0].scopes).toEqual ['source.python', 'variable.language.self.python']
-    expect(tokens[0][1].value).toBe '.'
-    expect(tokens[0][1].scopes).toEqual ['source.python']
-    expect(tokens[0][2].value).toBe 'foo'
-    expect(tokens[0][2].scopes).toEqual ['source.python']
+    expect(tokens[0][0]).toEqual value: 'self', scopes: ['source.python', 'variable.language.self.python']
+    expect(tokens[0][1]).toEqual value: '.', scopes: ['source.python', 'punctuation.separator.property.period.python']
+    expect(tokens[0][2]).toEqual value: 'foo', scopes: ['source.python', 'variable.other.property.python']
 
   it "tokenizes cls as a self-type variable", ->
     tokens = grammar.tokenizeLines('cls.foo')
 
-    expect(tokens[0][0].value).toBe 'cls'
-    expect(tokens[0][0].scopes).toEqual ['source.python', 'variable.language.self.python']
-    expect(tokens[0][1].value).toBe '.'
-    expect(tokens[0][1].scopes).toEqual ['source.python']
-    expect(tokens[0][2].value).toBe 'foo'
-    expect(tokens[0][2].scopes).toEqual ['source.python']
+    expect(tokens[0][0]).toEqual value: 'cls', scopes: ['source.python', 'variable.language.self.python']
+    expect(tokens[0][1]).toEqual value: '.', scopes: ['source.python', 'punctuation.separator.property.period.python']
+    expect(tokens[0][2]).toEqual value: 'foo', scopes: ['source.python', 'variable.other.property.python']
 
   it "tokenizes properties of a variable as variables", ->
     tokens = grammar.tokenizeLines('bar.foo')
 
-    expect(tokens[0][0].value).toBe 'bar'
-    expect(tokens[0][0].scopes).toEqual ['source.python']
-    expect(tokens[0][1].value).toBe '.'
-    expect(tokens[0][1].scopes).toEqual ['source.python']
-    expect(tokens[0][2].value).toBe 'foo'
-    expect(tokens[0][2].scopes).toEqual ['source.python']
+    expect(tokens[0][0]).toEqual value: 'bar', scopes: ['source.python', 'variable.other.object.python']
+    expect(tokens[0][1]).toEqual value: '.', scopes: ['source.python', 'punctuation.separator.property.period.python']
+    expect(tokens[0][2]).toEqual value: 'foo', scopes: ['source.python', 'variable.other.property.python']
 
   it "tokenizes async function definitions", ->
     {tokens} = grammar.tokenizeLine 'async def test(param):'
@@ -689,19 +680,19 @@ describe "Python grammar", ->
   it "tokenizes complex function calls", ->
     {tokens} = grammar.tokenizeLine "torch.nn.BCELoss()(Variable(bayes_optimal_prob, 1, requires_grad=False), Yvar).data[0]"
 
-    expect(tokens[4]).toEqual value: 'BCELoss', scopes: ['source.python', 'meta.function-call.python']
-    expect(tokens[5]).toEqual value: '(', scopes: ['source.python', 'meta.function-call.python', 'punctuation.definition.arguments.begin.python']
-    expect(tokens[6]).toEqual value: ')', scopes: ['source.python', 'meta.function-call.python', 'punctuation.definition.arguments.end.python']
-    expect(tokens[7]).toEqual value: '(', scopes: ['source.python', 'meta.function-call.python', 'punctuation.definition.arguments.begin.python']
-    expect(tokens[8]).toEqual value: 'Variable', scopes: ['source.python', 'meta.function-call.python', 'meta.function-call.arguments.python', 'meta.function-call.python']
-    expect(tokens[9]).toEqual value: '(', scopes: ['source.python', 'meta.function-call.python', 'meta.function-call.arguments.python', 'meta.function-call.python', 'punctuation.definition.arguments.begin.python']
+    expect(tokens[4]).toEqual value: 'BCELoss', scopes: ['source.python', 'meta.method-call.python', 'entity.name.function.python']
+    expect(tokens[5]).toEqual value: '(', scopes: ['source.python', 'meta.method-call.python', 'punctuation.definition.arguments.begin.bracket.round.python']
+    expect(tokens[6]).toEqual value: ')', scopes: ['source.python', 'meta.method-call.python', 'punctuation.definition.arguments.end.bracket.round.python']
+    expect(tokens[7]).toEqual value: '(', scopes: ['source.python', 'meta.function-call.python', 'punctuation.definition.arguments.begin.bracket.round.python']
+    expect(tokens[8]).toEqual value: 'Variable', scopes: ['source.python', 'meta.function-call.python', 'meta.function-call.arguments.python', 'meta.function-call.python', 'entity.name.function.python']
+    expect(tokens[9]).toEqual value: '(', scopes: ['source.python', 'meta.function-call.python', 'meta.function-call.arguments.python', 'meta.function-call.python', 'punctuation.definition.arguments.begin.bracket.round.python']
     expect(tokens[10]).toEqual value: 'bayes_optimal_prob', scopes: ['source.python', 'meta.function-call.python', 'meta.function-call.arguments.python', 'meta.function-call.python', 'meta.function-call.arguments.python']
-    expect(tokens[14]).toEqual value: 'requires_grad', scopes: ['source.python', 'meta.function-call.python', 'meta.function-call.arguments.python', 'meta.function-call.python', 'meta.function-call.arguments.python', 'variable.parameter.function.python']
-    expect(tokens[16]).toEqual value: 'False', scopes: ['source.python', 'meta.function-call.python', 'meta.function-call.arguments.python', 'meta.function-call.python', 'meta.function-call.arguments.python', 'constant.language.python']
-    expect(tokens[17]).toEqual value: ')', scopes: ['source.python', 'meta.function-call.python', 'meta.function-call.arguments.python', 'meta.function-call.python', 'punctuation.definition.arguments.end.python']
-    expect(tokens[18]).toEqual value: ', ', scopes: ['source.python', 'meta.function-call.python', 'meta.function-call.arguments.python']
-    expect(tokens[20]).toEqual value: ')', scopes: ['source.python', 'meta.function-call.python', 'punctuation.definition.arguments.end.python']
-    expect(tokens[21]).toEqual value: '.', scopes: ['source.python']
+    expect(tokens[16]).toEqual value: 'requires_grad', scopes: ['source.python', 'meta.function-call.python', 'meta.function-call.arguments.python', 'meta.function-call.python', 'meta.function-call.arguments.python', 'variable.parameter.function.python']
+    expect(tokens[18]).toEqual value: 'False', scopes: ['source.python', 'meta.function-call.python', 'meta.function-call.arguments.python', 'meta.function-call.python', 'meta.function-call.arguments.python', 'constant.language.python']
+    expect(tokens[19]).toEqual value: ')', scopes: ['source.python', 'meta.function-call.python', 'meta.function-call.arguments.python', 'meta.function-call.python', 'punctuation.definition.arguments.end.bracket.round.python']
+    expect(tokens[20]).toEqual value: ',', scopes: ['source.python', 'meta.function-call.python', 'meta.function-call.arguments.python', 'punctuation.separator.arguments.python']
+    expect(tokens[22]).toEqual value: ')', scopes: ['source.python', 'meta.function-call.python', 'punctuation.definition.arguments.end.bracket.round.python']
+    expect(tokens[23]).toEqual value: '.', scopes: ['source.python', 'punctuation.separator.property.period.python']
 
   it "tokenizes lambdas", ->
     {tokens} = grammar.tokenizeLine "lambda x, z = 4: x * z"
@@ -714,7 +705,7 @@ describe "Python grammar", ->
     expect(tokens[7]).toEqual value: '=', scopes: ['source.python', 'meta.function.inline.python', 'meta.function.inline.parameters.python', 'keyword.operator.assignment.python']
     expect(tokens[9]).toEqual value: '4', scopes: ['source.python', 'meta.function.inline.python', 'meta.function.inline.parameters.python', 'constant.numeric.integer.decimal.python']
     expect(tokens[10]).toEqual value: ':', scopes: ['source.python', 'meta.function.inline.python', 'punctuation.definition.function.begin.python']
-    expect(tokens[11]).toEqual value: ' ', scopes: ['source.python']
+    expect(tokens[11]).toEqual value: ' x ', scopes: ['source.python']
 
   it "tokenizes SQL inline highlighting on blocks", ->
     delimsByScope =


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

* Tokenize function names for function and method calls
* Tokenize objects and properties

| Before | After |
| ------- | ------ |
| ![language-python-before](https://user-images.githubusercontent.com/2766036/35310484-a70f7f24-007f-11e8-90d9-bb884e9f661b.png) | ![language-python-after](https://user-images.githubusercontent.com/2766036/35310440-65d9dfb8-007f-11e8-8df8-cab3f250c3ab.png)

Quite the difference if I do say so myself.  This brings language-python in line with other languages such as language-javascript, language-coffee-script, language-php, etc.

### Alternate Designs

None.

### Benefits

:sparkles: highlighting :sparkles:

### Possible Drawbacks

None.

### Applicable Issues

Fixes #170
Fixes #141