### PR TITLE
Inject Python string patterns into embedded SQL strings

### DIFF
--- a/grammars/python.cson
+++ b/grammars/python.cson
@@ -19,6 +19,16 @@
   'wsgi'
 ]
 'firstLineMatch': '^#![ \\t]*/.*\\bpython[\\d\\.]*\\b'
+'injections':
+  'L:source.python meta.embedded.sql':
+    'patterns': [
+      {
+        'include': '#string_formatting'
+      }
+      {
+        'include': '#escaped_char'
+      }
+    ]
 'patterns': [
   {
     'include': '#line_comments'
@@ -1620,6 +1630,7 @@
           '2':
             'name': 'meta.empty-string.double.python'
         'name': 'string.quoted.double.block.sql.python'
+        'contentName': 'meta.embedded.sql'
         'patterns': [
           {
              'begin': '(?=\\s*(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER|WITH))'
@@ -1629,12 +1640,6 @@
                   'include': 'source.sql'
                 }
              ]
-          }
-          {
-            'include': '#string_formatting'
-          }
-          {
-            'include': '#escaped_char'
           }
         ]
       }
@@ -1653,13 +1658,8 @@
           '3':
             'name': 'invalid.illegal.unclosed-string.python'
         'name': 'string.quoted.double.single-line.sql.python'
+        'contentName': 'meta.embedded.sql'
         'patterns': [
-          {
-            'include': '#string_formatting'
-          }
-          {
-            'include': '#escaped_char'
-          }
           {
             'include': 'source.sql'
           }
@@ -2201,6 +2201,7 @@
           '2':
             'name': 'meta.empty-string.single.python'
         'name': 'string.quoted.single.block.sql.python'
+        'contentName': 'meta.embedded.sql'
         'patterns': [
           {
              'begin': '(?=\\s*(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER|WITH))'
@@ -2210,12 +2211,6 @@
                   'include': 'source.sql'
                 }
              ]
-          }
-          {
-            'include': '#string_formatting'
-          }
-          {
-            'include': '#escaped_char'
           }
         ]
       }
@@ -2232,13 +2227,8 @@
           '2':
             'name': 'invalid.illegal.unclosed-string.python'
         'name': 'string.quoted.single.single-line.python'
+        'contentName': 'meta.embedded.sql'
         'patterns': [
-          {
-            'include': '#string_formatting'
-          }
-          {
-            'include': '#escaped_char'
-          }
           {
             'include': 'source.sql'
           }

--- a/spec/python-spec.coffee
+++ b/spec/python-spec.coffee
@@ -707,57 +707,59 @@ describe "Python grammar", ->
     expect(tokens[10]).toEqual value: ':', scopes: ['source.python', 'meta.function.inline.python', 'punctuation.definition.function.begin.python']
     expect(tokens[11]).toEqual value: ' x ', scopes: ['source.python']
 
-  it "tokenizes SQL inline highlighting on blocks", ->
-    delimsByScope =
-      "string.quoted.double.block.sql.python": '"""'
-      "string.quoted.single.block.sql.python": "'''"
+  # FIXME: These tests are quite useless as they don't actually use the language-sql package
+  describe "SQL highlighting", ->
+    it "tokenizes SQL inline highlighting on blocks", ->
+      delimsByScope =
+        "string.quoted.double.block.sql.python": '"""'
+        "string.quoted.single.block.sql.python": "'''"
 
-    for scope, delim in delimsByScope
-      tokens = grammar.tokenizeLines(
-        delim +
-        'SELECT bar
-        FROM foo'
-        + delim
-      )
-
-      expect(tokens[0][0]).toEqual value: delim, scopes: ['source.python', scope, 'punctuation.definition.string.begin.python']
-      expect(tokens[1][0]).toEqual value: 'SELECT bar', scopes: ['source.python', scope]
-      expect(tokens[2][0]).toEqual value: 'FROM foo', scopes: ['source.python', scope]
-      expect(tokens[3][0]).toEqual value: delim, scopes: ['source.python', scope, 'punctuation.definition.string.end.python']
-
-  it "tokenizes SQL inline highlighting on blocks with a CTE", ->
-    delimsByScope =
-      "string.quoted.double.block.sql.python": '"""'
-      "string.quoted.single.block.sql.python": "'''"
-
-    for scope, delim of delimsByScope
-      tokens = grammar.tokenizeLines("""
-        #{delim}
-        WITH example_cte AS (
-        SELECT bar
-        FROM foo
-        GROUP BY bar
+      for scope, delim in delimsByScope
+        tokens = grammar.tokenizeLines(
+          delim +
+          'SELECT bar
+          FROM foo'
+          + delim
         )
 
-        SELECT COUNT(*)
-        FROM example_cte
-        #{delim}
-      """)
+        expect(tokens[0][0]).toEqual value: delim, scopes: ['source.python', scope, 'punctuation.definition.string.begin.python']
+        expect(tokens[1][0]).toEqual value: 'SELECT bar', scopes: ['source.python', scope, 'meta.embedded.sql']
+        expect(tokens[2][0]).toEqual value: 'FROM foo', scopes: ['source.python', scope, 'meta.embedded.sql']
+        expect(tokens[3][0]).toEqual value: delim, scopes: ['source.python', scope, 'punctuation.definition.string.end.python']
 
-      expect(tokens[0][0]).toEqual value: delim, scopes: ['source.python', scope, 'punctuation.definition.string.begin.python']
-      expect(tokens[1][0]).toEqual value: 'WITH example_cte AS (', scopes: ['source.python', scope]
-      expect(tokens[2][0]).toEqual value: 'SELECT bar', scopes: ['source.python', scope]
-      expect(tokens[3][0]).toEqual value: 'FROM foo', scopes: ['source.python', scope]
-      expect(tokens[4][0]).toEqual value: 'GROUP BY bar', scopes: ['source.python', scope]
-      expect(tokens[5][0]).toEqual value: ')', scopes: ['source.python', scope]
-      expect(tokens[6][0]).toEqual value: '', scopes: ['source.python', scope]
-      expect(tokens[7][0]).toEqual value: 'SELECT COUNT(*)', scopes: ['source.python', scope]
-      expect(tokens[8][0]).toEqual value: 'FROM example_cte', scopes: ['source.python', scope]
-      expect(tokens[9][0]).toEqual value: delim, scopes: ['source.python', scope, 'punctuation.definition.string.end.python']
+    it "tokenizes SQL inline highlighting on blocks with a CTE", ->
+      delimsByScope =
+        "string.quoted.double.block.sql.python": '"""'
+        "string.quoted.single.block.sql.python": "'''"
 
-  it "tokenizes SQL inline highlighting on single line with a CTE", ->
-    {tokens} = grammar.tokenizeLine('\'WITH example_cte AS (SELECT bar FROM foo) SELECT COUNT(*) FROM example_cte\'')
+      for scope, delim of delimsByScope
+        tokens = grammar.tokenizeLines("""
+          #{delim}
+          WITH example_cte AS (
+          SELECT bar
+          FROM foo
+          GROUP BY bar
+          )
 
-    expect(tokens[0]).toEqual value: '\'', scopes: ['source.python', 'string.quoted.single.single-line.python', 'punctuation.definition.string.begin.python']
-    expect(tokens[1]).toEqual value: 'WITH example_cte AS (SELECT bar FROM foo) SELECT COUNT(*) FROM example_cte', scopes: ['source.python', 'string.quoted.single.single-line.python']
-    expect(tokens[2]).toEqual value: '\'', scopes: ['source.python', 'string.quoted.single.single-line.python', 'punctuation.definition.string.end.python']
+          SELECT COUNT(*)
+          FROM example_cte
+          #{delim}
+        """)
+
+        expect(tokens[0][0]).toEqual value: delim, scopes: ['source.python', scope, 'punctuation.definition.string.begin.python']
+        expect(tokens[1][0]).toEqual value: 'WITH example_cte AS (', scopes: ['source.python', scope, 'meta.embedded.sql']
+        expect(tokens[2][0]).toEqual value: 'SELECT bar', scopes: ['source.python', scope, 'meta.embedded.sql']
+        expect(tokens[3][0]).toEqual value: 'FROM foo', scopes: ['source.python', scope, 'meta.embedded.sql']
+        expect(tokens[4][0]).toEqual value: 'GROUP BY bar', scopes: ['source.python', scope, 'meta.embedded.sql']
+        expect(tokens[5][0]).toEqual value: ')', scopes: ['source.python', scope, 'meta.embedded.sql']
+        expect(tokens[6][0]).toEqual value: '', scopes: ['source.python', scope, 'meta.embedded.sql']
+        expect(tokens[7][0]).toEqual value: 'SELECT COUNT(*)', scopes: ['source.python', scope, 'meta.embedded.sql']
+        expect(tokens[8][0]).toEqual value: 'FROM example_cte', scopes: ['source.python', scope, 'meta.embedded.sql']
+        expect(tokens[9][0]).toEqual value: delim, scopes: ['source.python', scope, 'punctuation.definition.string.end.python']
+
+    it "tokenizes SQL inline highlighting on single line with a CTE", ->
+      {tokens} = grammar.tokenizeLine('\'WITH example_cte AS (SELECT bar FROM foo) SELECT COUNT(*) FROM example_cte\'')
+
+      expect(tokens[0]).toEqual value: '\'', scopes: ['source.python', 'string.quoted.single.single-line.python', 'punctuation.definition.string.begin.python']
+      expect(tokens[1]).toEqual value: 'WITH example_cte AS (SELECT bar FROM foo) SELECT COUNT(*) FROM example_cte', scopes: ['source.python', 'string.quoted.single.single-line.python', 'meta.embedded.sql']
+      expect(tokens[2]).toEqual value: '\'', scopes: ['source.python', 'string.quoted.single.single-line.python', 'punctuation.definition.string.end.python']


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

atom/language-sql#70 now uses some begin/end patterns, which messes with language-python's ability to tokenize escaped characters and formatting specifiers in them.  To work around that, we now inject those patterns with the highest priority when an embedded SQL string is detected.

### Alternate Designs

Don't use begin/end patterns to match parentheses in language-sql.

### Benefits

Backslashes in embedded SQL strings should be tokenized correctly again.

### Possible Drawbacks

None?

### Applicable Issues

Fixes #240