### PR TITLE
Not all docstrings are SQL

### DIFF
--- a/grammars/python.cson
+++ b/grammars/python.cson
@@ -1629,11 +1629,11 @@
             'name': 'punctuation.definition.string.end.python'
           '2':
             'name': 'meta.empty-string.double.python'
-        'name': 'string.quoted.double.block.sql.python'
-        'contentName': 'meta.embedded.sql'
+        'name': 'string.quoted.double.block.python'
         'patterns': [
           {
              'begin': '(?=\\s*(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER|WITH))'
+             'name': 'meta.embedded.sql'
              'end': '(?=\\s*""")'
              'patterns': [
                 {
@@ -2200,12 +2200,12 @@
             'name': 'punctuation.definition.string.end.python'
           '2':
             'name': 'meta.empty-string.single.python'
-        'name': 'string.quoted.single.block.sql.python'
-        'contentName': 'meta.embedded.sql'
+        'name': 'string.quoted.single.block.python'
         'patterns': [
           {
              'begin': '(?=\\s*(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER|WITH))'
              'end': '(?=\\s*\'\'\')'
+             'name': 'meta.embedded.sql'
              'patterns': [
                 {
                   'include': 'source.sql'

--- a/spec/python-spec.coffee
+++ b/spec/python-spec.coffee
@@ -374,6 +374,29 @@ describe "Python grammar", ->
       expect(tokens[4]).toEqual value: 'st', scopes: ['source.python', "string.quoted.single.single-line.binary.python"]
       expect(tokens[5]).toEqual value: "'", scopes: ['source.python', "string.quoted.single.single-line.binary.python", 'punctuation.definition.string.end.python']
 
+  describe "docstrings", ->
+    it "tokenizes them", ->
+      lines = grammar.tokenizeLines '''
+        """
+          Bla bla bla "wow" what's this?
+        """
+      '''
+
+      expect(lines[0][0]).toEqual value: '"""', scopes: ['source.python', 'string.quoted.double.block.python', 'punctuation.definition.string.begin.python']
+      expect(lines[1][0]).toEqual value: '  Bla bla bla "wow" what\'s this?', scopes: ['source.python', 'string.quoted.double.block.python']
+      expect(lines[2][0]).toEqual value: '"""', scopes: ['source.python', 'string.quoted.double.block.python', 'punctuation.definition.string.end.python']
+
+      lines = grammar.tokenizeLines """
+        '''
+          Bla bla bla "wow" what's this?
+        '''
+      """
+
+      expect(lines[0][0]).toEqual value: "'''", scopes: ['source.python', 'string.quoted.single.block.python', 'punctuation.definition.string.begin.python']
+      expect(lines[1][0]).toEqual value: '  Bla bla bla "wow" what\'s this?', scopes: ['source.python', 'string.quoted.single.block.python']
+      expect(lines[2][0]).toEqual value: "'''", scopes: ['source.python', 'string.quoted.single.block.python', 'punctuation.definition.string.end.python']
+
+
   describe "string formatting", ->
     describe "%-style formatting", ->
       it "tokenizes the conversion type", ->
@@ -733,9 +756,11 @@ describe "Python grammar", ->
         expect(tokens[3][0]).toEqual value: delim, scopes: ['source.python', scope, 'punctuation.definition.string.end.python']
 
     it "tokenizes SQL inline highlighting on blocks with a CTE", ->
+      # Note that these scopes do not contain .sql because we can't definitively tell
+      # if the string contains SQL or not
       delimsByScope =
-        "string.quoted.double.block.sql.python": '"""'
-        "string.quoted.single.block.sql.python": "'''"
+        "string.quoted.double.block.python": '"""'
+        "string.quoted.single.block.python": "'''"
 
       for scope, delim of delimsByScope
         tokens = grammar.tokenizeLines("""


### PR DESCRIPTION
My fix in #243 was causing all docstrings to be tokenized as `meta.embedded.sql`.  I fixed that by only adding that scope when SQL is detected and adding some basic docstring tests.