### PR TITLE
Migrate to Atom-Grammar-Tests

### DIFF
--- a/grammars/python.cson
+++ b/grammars/python.cson
@@ -289,15 +289,17 @@
           {
             # param = 3
             # param: int = 3
-            'begin': '\\b([a-zA-Z_][\\w_]*)\\s*(?:(:)\\s*([a-zA-Z_][\\w_]*))?\\s*(=)\\s*'
+            'begin': '(?:(\\*{0,2})|\\b)([a-zA-Z_][\\w_]*)\\s*(?:(:)\\s*([a-zA-Z_][\\w_]*))?\\s*(=)\\s*'
             'beginCaptures':
               '1':
-                'name': 'variable.parameter.function.python'
+                'name': 'keyword.operator.unpacking.arguments.python'
               '2':
-                'name': 'punctuation.separator.python'
+                'name': 'variable.parameter.function.python'
               '3':
-                'name': 'storage.type.python'
+                'name': 'punctuation.separator.python'
               '4':
+                'name': 'storage.type.python'
+              '5':
                 'name': 'keyword.operator.assignment.python'
             'end': '(?!\\G)'
             'patterns': [
@@ -309,13 +311,15 @@
           {
             # param
             # param: int
-            'match': '\\b([a-zA-Z_][\\w_]*)\\s*(?:(:)\\s*([a-zA-Z_][\\w_]*))?'
+            'match': '(?:(\\*{0,2})|\\b)([a-zA-Z_][\\w_]*)\\s*(?:(:)\\s*([a-zA-Z_][\\w_]*))?'
             'captures':
               '1':
-                'name': 'variable.parameter.function.python'
+                'name': 'keyword.operator.unpacking.arguments.python'
               '2':
-                'name': 'punctuation.separator.python'
+                'name': 'variable.parameter.function.python'
               '3':
+                'name': 'punctuation.separator.python'
+              '4':
                 'name': 'storage.type.python'
           }
           {
@@ -352,11 +356,13 @@
         'patterns': [
           {
             # param = 3
-            'begin': '\\b([a-zA-Z_][\\w_]*)\\s*(=)\\s*'
+            'begin': '(?:(\\*{0,2})|\\b)([a-zA-Z_][\\w_]*)\\s*(=)\\s*'
             'beginCaptures':
               '1':
-                'name': 'variable.parameter.function.python'
+                'name': 'keyword.operator.unpacking.arguments.python'
               '2':
+                'name': 'variable.parameter.function.python'
+              '3':
                 'name': 'keyword.operator.assignment.python'
             'end': '(?!\\G)'
             'patterns': [
@@ -367,8 +373,12 @@
           }
           {
             # param
-            'match': '\\b([a-zA-Z_][\\w_]*)\\b'
-            'name': 'variable.parameter.function.python'
+            'match': '(?:(\\*{0,2})|\\b)([a-zA-Z_][\\w_]*)\\b'
+            'captures':
+              '1':
+                'name': 'keyword.operator.unpacking.arguments.python'
+              '2':
+                'name': 'variable.parameter.function.python'
           }
           {
             'match': ','

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "url": "https://github.com/atom/language-python/issues"
   },
   "dependencies": {
+    "atom-grammar-test": "^0.6.4",
     "tree-sitter-python": "^0.11.3"
   },
   "devDependencies": {

--- a/spec/fixtures/grammar/syntax_test_python.py
+++ b/spec/fixtures/grammar/syntax_test_python.py
@@ -5,16 +5,10 @@ def my_func(first, second=False, *third, **forth):
 # <- storage.type.function
 #   ^^^^^^^ entity.name.function
 #          ^ punctuation.definition.parameters.begin
-#           ^^^^^ variable.parameter.function
-#                ^ punctuation.separator.parameters
-#                  ^^^^^^ variable.parameter.function
+#           ^^^^^  ^^^^^^         ^^^^^    ^^^^^ variable.parameter.function
+#                ^             ^       ^ punctuation.separator.parameters
 #                        ^ keyword.operator.assignment
 #                         ^^^^^ constant
-#                              ^ punctuation.separator.parameters
-#                                ^ keyword.operator.unpacking.arguments
-#                                 ^^^^^ variable.parameter.function
-#                                      ^ punctuation.separator.parameters
-#                                        ^^ keyword.operator.unpacking.arguments
-#                                          ^^^^^ variable.parameter.function
+#                                ^       ^^ keyword.operator.unpacking.arguments
 #                                                ^ punctuation.definition.function.begin
     pass

--- a/spec/fixtures/grammar/syntax_test_python.py
+++ b/spec/fixtures/grammar/syntax_test_python.py
@@ -18,21 +18,3 @@ def my_func(first, second=False, *third, **forth):
 #                                          ^^^^^ variable.parameter.function
 #                                                ^ punctuation.definition.function.begin
     pass
-
-
-my_func2 = lambda x, y=2, *z, **kw: x + y + 1
-#        ^ keyword.operator.assignment
-#           ^^^^^ meta.function.inline storage.type.function.inline
-#                 ^^^^^^^^^^^^^^^^ meta.function.inline.parameters
-#                 ^ variable.parameter.function
-#                  ^ punctuation.separator.parameters
-#                    ^ variable.parameter.function
-#                     ^ keyword.operator.assignment
-#                      ^ constant
-#                       ^ punctuation.separator.parameters
-#                         ^ keyword.operator.unpacking.arguments
-#                          ^ variable.parameter.function
-#                           ^ punctuation.separator.parameters
-#                             ^^ keyword.operator.unpacking.arguments
-#                               ^^ variable.parameter.function
-#                                 ^ punctuation.definition.function.begin

--- a/spec/fixtures/grammar/syntax_test_python.py
+++ b/spec/fixtures/grammar/syntax_test_python.py
@@ -11,8 +11,10 @@ def my_func(first, second=False, *third, **forth):
 #                        ^ keyword.operator.assignment
 #                         ^^^^^ constant
 #                              ^ punctuation.separator.parameters
+#                                ^ keyword.operator.unpacking.arguments
 #                                 ^^^^^ variable.parameter.function
 #                                      ^ punctuation.separator.parameters
+#                                        ^^ keyword.operator.unpacking.arguments
 #                                          ^^^^^ variable.parameter.function
 #                                                ^ punctuation.definition.function.begin
     pass
@@ -28,7 +30,9 @@ my_func2 = lambda x, y=2, *z, **kw: x + y + 1
 #                     ^ keyword.operator.assignment
 #                      ^ constant
 #                       ^ punctuation.separator.parameters
+#                         ^ keyword.operator.unpacking.arguments
 #                          ^ variable.parameter.function
 #                           ^ punctuation.separator.parameters
+#                             ^^ keyword.operator.unpacking.arguments
 #                               ^^ variable.parameter.function
 #                                 ^ punctuation.definition.function.begin

--- a/spec/fixtures/grammar/syntax_test_python.py
+++ b/spec/fixtures/grammar/syntax_test_python.py
@@ -1,0 +1,34 @@
+# SYNTAX TEST "source.python"
+
+
+def my_func(first, second=False, *third, **forth):
+# <- storage.type.function
+#   ^^^^^^^ entity.name.function
+#          ^ punctuation.definition.parameters.begin
+#           ^^^^^ variable.parameter.function
+#                ^ punctuation.separator.parameters
+#                  ^^^^^^ variable.parameter.function
+#                        ^ keyword.operator.assignment
+#                         ^^^^^ constant
+#                              ^ punctuation.separator.parameters
+#                                 ^^^^^ variable.parameter.function
+#                                      ^ punctuation.separator.parameters
+#                                          ^^^^^ variable.parameter.function
+#                                                ^ punctuation.definition.function.begin
+    pass
+
+
+my_func2 = lambda x, y=2, *z, **kw: x + y + 1
+#        ^ keyword.operator.assignment
+#           ^^^^^ meta.function.inline storage.type.function.inline
+#                 ^^^^^^^^^^^^^^^^ meta.function.inline.parameters
+#                 ^ variable.parameter.function
+#                  ^ punctuation.separator.parameters
+#                    ^ variable.parameter.function
+#                     ^ keyword.operator.assignment
+#                      ^ constant
+#                       ^ punctuation.separator.parameters
+#                          ^ variable.parameter.function
+#                           ^ punctuation.separator.parameters
+#                               ^^ variable.parameter.function
+#                                 ^ punctuation.definition.function.begin

--- a/spec/fixtures/grammar/syntax_test_python_functions.py
+++ b/spec/fixtures/grammar/syntax_test_python_functions.py
@@ -1,0 +1,88 @@
+# SYNTAX TEST "source.python"
+
+
+# it "tokenizes async function definitions"
+async def test(param):
+# <- meta.function.python storage.modifier.async.python
+#     ^^^ storage.type.function.python
+#         ^^^^ entity.name.function.python
+    pass
+
+
+# it "tokenizes comments inside function parameters"
+def test(arg, # comment')
+# <- meta.function.python storage.type.function.python
+#   ^^^^ entity.name.function.python
+#       ^ punctuation.definition.parameters.begin.python
+#        ^^^^^^^^^^^^^^^^ meta.function.parameters.python
+#        ^^^ variable.parameter.function.python
+#           ^ punctuation.separator.parameters.python
+#             ^ comment.line.number-sign.python punctuation.definition.comment.python
+#               ^^^^^^^ comment.line.number-sign.python
+    ):
+    pass
+
+
+def __init__(
+# <- meta.function.python storage.type.function.python
+#   ^^^^^^^^ entity.name.function.python support.function.magic.python
+#           ^ punctuation.definition.parameters.begin.python
+    self,
+#   ^^^^^ meta.function.parameters.python
+#   ^^^^ variable.parameter.function.python
+#       ^ punctuation.separator.parameters.python
+    codec, # comment
+#   ^^^^^^^^^^^^^^^^ meta.function.parameters.python
+#   ^^^^^ variable.parameter.function.python
+#        ^ punctuation.separator.parameters.python
+#          ^ comment.line.number-sign.python punctuation.definition.comment.python
+#            ^^^^^^^ comment.line.number-sign.python
+    config
+#   ^^^^^^ meta.function.parameters.python variable.parameter.function.python
+# >> meta.function.python
+):
+# <- punctuation.definition.parameters.end.python
+#^ punctuation.definition.function.begin.python
+    pass
+
+
+# it "tokenizes a function definition with annotations"
+def f(a: None, b: int = 3) -> int:
+# <- meta.function.python storage.type.function.python
+#   ^ entity.name.function.python
+#    ^ punctuation.definition.parameters.begin.python
+#     ^^^^^^^^^^^^^^^^^^^ meta.function.parameters.python
+#     ^ variable.parameter.function.python
+#      ^ punctuation.separator.python
+#        ^^^^ storage.type.python
+#            ^ punctuation.separator.parameters.python
+#              ^ variable.parameter.function.python
+#               ^ punctuation.separator.python
+#                 ^^^ storage.type.python
+#                     ^ keyword.operator.assignment.python
+#                       ^ constant.numeric.integer.decimal.python
+#                        ^ punctuation.definition.parameters.end.python
+#                          ^^ keyword.operator.function-annotation.python
+#                             ^^^ storage.type.python
+#                                ^ punctuation.definition.function.begin.python
+    pass
+
+
+# it "tokenizes complex function calls"
+torch.nn.BCELoss()(Variable(bayes_optimal_prob, 1, requires_grad=False), Yvar).data[0]
+#        ^^^^^^^^^ meta.method-call.python
+#        ^^^^^^^ entity.name.function.python
+#               ^ punctuation.definition.arguments.begin.bracket.round.python
+#                ^ punctuation.definition.arguments.end.bracket.round.python
+#                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.python
+#                 ^ punctuation.definition.arguments.begin.bracket.round.python
+#                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.python
+#                  ^^^^^^^^ entity.name.function.python
+#                          ^ punctuation.definition.arguments.begin.bracket.round.python
+#                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.python
+#                                                  ^^^^^^^^^^^^^ variable.parameter.function.python
+#                                                                ^^^^^ constant.language.python
+#                                                                     ^ punctuation.definition.arguments.end.bracket.round.python
+#                                                                      ^ punctuation.separator.arguments.python
+#                                                                            ^ punctuation.definition.arguments.end.bracket.round.python
+#                                                                             ^ punctuation.separator.property.period.python

--- a/spec/fixtures/grammar/syntax_test_python_lambdas.py
+++ b/spec/fixtures/grammar/syntax_test_python_lambdas.py
@@ -25,3 +25,17 @@ lambda x, z = 4: x * z
 #           ^ keyword.operator.assignment.python
 #             ^ constant.numeric.integer.decimal.python
 #              ^ punctuation.definition.function.begin.python
+
+
+lambda: None
+# ^^^^ meta.function.inline.python
+# <- storage.type.function.inline.python
+#     ^ punctuation.definition.function.begin.python
+
+
+not_a_lambda.foo
+# <- ! meta.function.inline.python
+
+
+lambda_not.foo
+# <- ! meta.function.inline.python

--- a/spec/fixtures/grammar/syntax_test_python_lambdas.py
+++ b/spec/fixtures/grammar/syntax_test_python_lambdas.py
@@ -1,0 +1,32 @@
+# SYNTAX TEST "source.python"
+
+
+my_func2 = lambda x, y=2, *z, **kw: x + y + 1
+#        ^ keyword.operator.assignment
+#           ^^^^^ meta.function.inline storage.type.function.inline
+#                 ^^^^^^^^^^^^^^^^ meta.function.inline.parameters
+#                 ^ variable.parameter.function
+#                  ^ punctuation.separator.parameters
+#                    ^ variable.parameter.function
+#                     ^ keyword.operator.assignment
+#                      ^ constant
+#                       ^ punctuation.separator.parameters
+#                         ^ keyword.operator.unpacking.arguments
+#                          ^ variable.parameter.function
+#                           ^ punctuation.separator.parameters
+#                             ^^ keyword.operator.unpacking.arguments
+#                               ^^ variable.parameter.function
+#                                 ^ punctuation.definition.function.begin
+
+
+lambda x, z = 4: x * z
+# <- source.python meta.function.inline.python storage.type.function.inline.python
+#     ^ source.python meta.function.inline.python
+#      ^ source.python meta.function.inline.python meta.function.inline.parameters.python variable.parameter.function.python
+#       ^ source.python meta.function.inline.python meta.function.inline.parameters.python punctuation.separator.parameters.python
+#        ^ source.python meta.function.inline.python
+#         ^ source.python meta.function.inline.python meta.function.inline.parameters.python variable.parameter.function.python
+#           ^ source.python meta.function.inline.python meta.function.inline.parameters.python keyword.operator.assignment.python
+#             ^ source.python meta.function.inline.python meta.function.inline.parameters.python constant.numeric.integer.decimal.python
+#              ^ source.python meta.function.inline.python punctuation.definition.function.begin.python
+#               ^^^^^^ source.python

--- a/spec/fixtures/grammar/syntax_test_python_lambdas.py
+++ b/spec/fixtures/grammar/syntax_test_python_lambdas.py
@@ -3,30 +3,25 @@
 
 my_func2 = lambda x, y=2, *z, **kw: x + y + 1
 #        ^ keyword.operator.assignment
-#           ^^^^^ meta.function.inline storage.type.function.inline
+#          ^^^^^^^^^^^^^^^^^^^^^^^ meta.function.inline
+#           ^^^^^ storage.type.function.inline
 #                 ^^^^^^^^^^^^^^^^ meta.function.inline.parameters
-#                 ^ variable.parameter.function
-#                  ^ punctuation.separator.parameters
+#                 ^  ^     ^    ^^ variable.parameter.function
+#                  ^    ^   ^ punctuation.separator.parameters
 #                    ^ variable.parameter.function
 #                     ^ keyword.operator.assignment
 #                      ^ constant
-#                       ^ punctuation.separator.parameters
-#                         ^ keyword.operator.unpacking.arguments
+#                         ^   ^^ keyword.operator.unpacking.arguments
 #                          ^ variable.parameter.function
-#                           ^ punctuation.separator.parameters
-#                             ^^ keyword.operator.unpacking.arguments
-#                               ^^ variable.parameter.function
 #                                 ^ punctuation.definition.function.begin
 
 
 lambda x, z = 4: x * z
-# <- source.python meta.function.inline.python storage.type.function.inline.python
-#     ^ source.python meta.function.inline.python
-#      ^ source.python meta.function.inline.python meta.function.inline.parameters.python variable.parameter.function.python
-#       ^ source.python meta.function.inline.python meta.function.inline.parameters.python punctuation.separator.parameters.python
-#        ^ source.python meta.function.inline.python
-#         ^ source.python meta.function.inline.python meta.function.inline.parameters.python variable.parameter.function.python
-#           ^ source.python meta.function.inline.python meta.function.inline.parameters.python keyword.operator.assignment.python
-#             ^ source.python meta.function.inline.python meta.function.inline.parameters.python constant.numeric.integer.decimal.python
-#              ^ source.python meta.function.inline.python punctuation.definition.function.begin.python
-#               ^^^^^^ source.python
+# ^^^^^^^^^^^^^ meta.function.inline.python
+# <- storage.type.function.inline.python
+#      ^^^^^^^^ meta.function.inline.parameters.python
+#      ^  ^ variable.parameter.function.python
+#       ^ punctuation.separator.parameters.python
+#           ^ keyword.operator.assignment.python
+#             ^ constant.numeric.integer.decimal.python
+#              ^ punctuation.definition.function.begin.python

--- a/spec/fixtures/grammar/syntax_test_python_typing.py
+++ b/spec/fixtures/grammar/syntax_test_python_typing.py
@@ -1,0 +1,23 @@
+# SYNTAX TEST "source.python"
+
+
+def right_hand_split(
+# <- storage.type.function
+#   ^^^^^^^^^^^^^^^^ entity.name.function
+#                   ^ punctuation.definition.parameters.begin
+    line: Line, py36: bool = False, omit: Collection[LeafID] = ()
+#   ^^^^ variable.parameter.function
+#       ^ punctuation.separator
+#         ^^^^ storage.type
+#             ^ punctuation.separator.parameters
+#               ^^^^ variable.parameter.function
+#                   ^ punctuation.separator
+#                     ^^^^ storage.type
+#                          ^ keyword.operator.assignment
+#                            ^^^^^ constant
+#                                 ^ punctuation.separator.parameters
+#                                   ^^^^ variable.parameter.function
+#                                       ^ punctuation.separator
+) -> Iterator[Line]:
+#                  ^ punctuation.definition.function.begin
+    pass

--- a/spec/python-spec.coffee
+++ b/spec/python-spec.coffee
@@ -643,85 +643,9 @@ describe "Python grammar", ->
     expect(tokens[0][1]).toEqual value: '.', scopes: ['source.python', 'punctuation.separator.property.period.python']
     expect(tokens[0][2]).toEqual value: 'foo', scopes: ['source.python', 'variable.other.property.python']
 
-  it "tokenizes async function definitions", ->
-    {tokens} = grammar.tokenizeLine 'async def test(param):'
-
-    expect(tokens[0]).toEqual value: 'async', scopes: ['source.python', 'meta.function.python', 'storage.modifier.async.python']
-    expect(tokens[1]).toEqual value: ' ', scopes: ['source.python', 'meta.function.python']
-    expect(tokens[2]).toEqual value: 'def', scopes: ['source.python', 'meta.function.python', 'storage.type.function.python']
-    expect(tokens[4]).toEqual value: 'test', scopes: ['source.python', 'meta.function.python', 'entity.name.function.python']
-
-  it "tokenizes comments inside function parameters", ->
-    {tokens} = grammar.tokenizeLine('def test(arg, # comment')
-
-    expect(tokens[0]).toEqual value: 'def', scopes: ['source.python', 'meta.function.python', 'storage.type.function.python']
-    expect(tokens[2]).toEqual value: 'test', scopes: ['source.python', 'meta.function.python', 'entity.name.function.python']
-    expect(tokens[3]).toEqual value: '(', scopes: ['source.python', 'meta.function.python', 'punctuation.definition.parameters.begin.python']
-    expect(tokens[4]).toEqual value: 'arg', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'variable.parameter.function.python']
-    expect(tokens[5]).toEqual value: ',', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'punctuation.separator.parameters.python']
-    expect(tokens[7]).toEqual value: '#', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'comment.line.number-sign.python', 'punctuation.definition.comment.python']
-    expect(tokens[8]).toEqual value: ' comment', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'comment.line.number-sign.python']
-
-    tokens = grammar.tokenizeLines("""
-      def __init__(
-        self,
-        codec, # comment
-        config
-      ):
-    """)
-
-    expect(tokens[0][0]).toEqual value: 'def', scopes: ['source.python', 'meta.function.python', 'storage.type.function.python']
-    expect(tokens[0][2]).toEqual value: '__init__', scopes: ['source.python', 'meta.function.python', 'entity.name.function.python', 'support.function.magic.python']
-    expect(tokens[0][3]).toEqual value: '(', scopes: ['source.python', 'meta.function.python', 'punctuation.definition.parameters.begin.python']
-    expect(tokens[1][1]).toEqual value: 'self', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'variable.parameter.function.python']
-    expect(tokens[1][2]).toEqual value: ',', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'punctuation.separator.parameters.python']
-    expect(tokens[2][1]).toEqual value: 'codec', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'variable.parameter.function.python']
-    expect(tokens[2][2]).toEqual value: ',', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'punctuation.separator.parameters.python']
-    expect(tokens[2][4]).toEqual value: '#', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'comment.line.number-sign.python', 'punctuation.definition.comment.python']
-    expect(tokens[2][5]).toEqual value: ' comment', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'comment.line.number-sign.python']
-    expect(tokens[3][1]).toEqual value: 'config', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'variable.parameter.function.python']
-    expect(tokens[4][0]).toEqual value: ')', scopes: ['source.python', 'meta.function.python', 'punctuation.definition.parameters.end.python']
-    expect(tokens[4][1]).toEqual value: ':', scopes: ['source.python', 'meta.function.python', 'punctuation.definition.function.begin.python']
-
-  it "tokenizes a function definition with annotations", ->
-    {tokens} = grammar.tokenizeLine 'def f(a: None, b: int = 3) -> int:'
-
-    expect(tokens[0]).toEqual value: 'def', scopes: ['source.python', 'meta.function.python', 'storage.type.function.python']
-    expect(tokens[2]).toEqual value: 'f', scopes: ['source.python', 'meta.function.python', 'entity.name.function.python']
-    expect(tokens[3]).toEqual value: '(', scopes: ['source.python', 'meta.function.python', 'punctuation.definition.parameters.begin.python']
-    expect(tokens[4]).toEqual value: 'a', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'variable.parameter.function.python']
-    expect(tokens[5]).toEqual value: ':', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'punctuation.separator.python']
-    expect(tokens[7]).toEqual value: 'None', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'storage.type.python']
-    expect(tokens[8]).toEqual value: ',', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'punctuation.separator.parameters.python']
-    expect(tokens[10]).toEqual value: 'b', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'variable.parameter.function.python']
-    expect(tokens[11]).toEqual value: ':', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'punctuation.separator.python']
-    expect(tokens[13]).toEqual value: 'int', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'storage.type.python']
-    expect(tokens[15]).toEqual value: '=', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'keyword.operator.assignment.python']
-    expect(tokens[17]).toEqual value: '3', scopes: ['source.python', 'meta.function.python', 'meta.function.parameters.python', 'constant.numeric.integer.decimal.python']
-    expect(tokens[18]).toEqual value: ')', scopes: ['source.python', 'meta.function.python', 'punctuation.definition.parameters.end.python']
-    expect(tokens[20]).toEqual value: '->', scopes: ['source.python', 'meta.function.python', 'keyword.operator.function-annotation.python']
-    expect(tokens[22]).toEqual value: 'int', scopes: ['source.python', 'meta.function.python', 'storage.type.python']
-    expect(tokens[23]).toEqual value: ':', scopes: ['source.python', 'meta.function.python', 'punctuation.definition.function.begin.python']
-
-  it "tokenizes complex function calls", ->
-    {tokens} = grammar.tokenizeLine "torch.nn.BCELoss()(Variable(bayes_optimal_prob, 1, requires_grad=False), Yvar).data[0]"
-
-    expect(tokens[4]).toEqual value: 'BCELoss', scopes: ['source.python', 'meta.method-call.python', 'entity.name.function.python']
-    expect(tokens[5]).toEqual value: '(', scopes: ['source.python', 'meta.method-call.python', 'punctuation.definition.arguments.begin.bracket.round.python']
-    expect(tokens[6]).toEqual value: ')', scopes: ['source.python', 'meta.method-call.python', 'punctuation.definition.arguments.end.bracket.round.python']
-    expect(tokens[7]).toEqual value: '(', scopes: ['source.python', 'meta.function-call.python', 'punctuation.definition.arguments.begin.bracket.round.python']
-    expect(tokens[8]).toEqual value: 'Variable', scopes: ['source.python', 'meta.function-call.python', 'meta.function-call.arguments.python', 'meta.function-call.python', 'entity.name.function.python']
-    expect(tokens[9]).toEqual value: '(', scopes: ['source.python', 'meta.function-call.python', 'meta.function-call.arguments.python', 'meta.function-call.python', 'punctuation.definition.arguments.begin.bracket.round.python']
-    expect(tokens[10]).toEqual value: 'bayes_optimal_prob', scopes: ['source.python', 'meta.function-call.python', 'meta.function-call.arguments.python', 'meta.function-call.python', 'meta.function-call.arguments.python']
-    expect(tokens[16]).toEqual value: 'requires_grad', scopes: ['source.python', 'meta.function-call.python', 'meta.function-call.arguments.python', 'meta.function-call.python', 'meta.function-call.arguments.python', 'variable.parameter.function.python']
-    expect(tokens[18]).toEqual value: 'False', scopes: ['source.python', 'meta.function-call.python', 'meta.function-call.arguments.python', 'meta.function-call.python', 'meta.function-call.arguments.python', 'constant.language.python']
-    expect(tokens[19]).toEqual value: ')', scopes: ['source.python', 'meta.function-call.python', 'meta.function-call.arguments.python', 'meta.function-call.python', 'punctuation.definition.arguments.end.bracket.round.python']
-    expect(tokens[20]).toEqual value: ',', scopes: ['source.python', 'meta.function-call.python', 'meta.function-call.arguments.python', 'punctuation.separator.arguments.python']
-    expect(tokens[22]).toEqual value: ')', scopes: ['source.python', 'meta.function-call.python', 'punctuation.definition.arguments.end.bracket.round.python']
-    expect(tokens[23]).toEqual value: '.', scopes: ['source.python', 'punctuation.separator.property.period.python']
-
   # Add the grammar test fixtures
   grammarTest path.join(__dirname, 'fixtures/grammar/syntax_test_python.py')
+  grammarTest path.join(__dirname, 'fixtures/grammar/syntax_test_python_functions.py')
   grammarTest path.join(__dirname, 'fixtures/grammar/syntax_test_python_lambdas.py')
   grammarTest path.join(__dirname, 'fixtures/grammar/syntax_test_python_typing.py')
 

--- a/spec/python-spec.coffee
+++ b/spec/python-spec.coffee
@@ -1,3 +1,6 @@
+path = require 'path'
+grammarTest = require 'atom-grammar-test'
+
 describe "Python grammar", ->
   grammar = null
 
@@ -729,18 +732,9 @@ describe "Python grammar", ->
     expect(tokens[10]).toEqual value: ':', scopes: ['source.python', 'meta.function.inline.python', 'punctuation.definition.function.begin.python']
     expect(tokens[11]).toEqual value: ' x ', scopes: ['source.python']
 
-  it "tokenizes lambdas without arguments", ->
-    {tokens} = grammar.tokenizeLine "lambda: None"
-    expect(tokens[0]).toEqual value: 'lambda', scopes: ['source.python', 'meta.function.inline.python', 'storage.type.function.inline.python']
-    expect(tokens[1]).toEqual value: ':', scopes: ['source.python', 'meta.function.inline.python', 'punctuation.definition.function.begin.python']
-
-  it "does not tokenizes a variable name ending with lambda as a lambda", ->
-    {tokens} = grammar.tokenizeLine "not_a_lambda.foo"
-    expect(tokens[0]).toEqual value: 'not_a_lambda', scopes: ['source.python', 'variable.other.object.python']
-
-  it "does not tokenizes a variable name starting with lambda as a lambda", ->
-    {tokens} = grammar.tokenizeLine "lambda_not.foo"
-    expect(tokens[0]).toEqual value: 'lambda_not', scopes: ['source.python', 'variable.other.object.python']
+  # Add the grammar test fixtures
+  grammarTest path.join(__dirname, 'fixtures/grammar/syntax_test_python.py')
+  grammarTest path.join(__dirname, 'fixtures/grammar/syntax_test_python_typing.py')
 
   describe "SQL highlighting", ->
     beforeEach ->

--- a/spec/python-spec.coffee
+++ b/spec/python-spec.coffee
@@ -720,20 +720,9 @@ describe "Python grammar", ->
     expect(tokens[22]).toEqual value: ')', scopes: ['source.python', 'meta.function-call.python', 'punctuation.definition.arguments.end.bracket.round.python']
     expect(tokens[23]).toEqual value: '.', scopes: ['source.python', 'punctuation.separator.property.period.python']
 
-  it "tokenizes lambdas", ->
-    {tokens} = grammar.tokenizeLine "lambda x, z = 4: x * z"
-
-    expect(tokens[0]).toEqual value: 'lambda', scopes: ['source.python', 'meta.function.inline.python', 'storage.type.function.inline.python']
-    expect(tokens[2]).toEqual value: 'x', scopes: ['source.python', 'meta.function.inline.python', 'meta.function.inline.parameters.python', 'variable.parameter.function.python']
-    expect(tokens[3]).toEqual value: ',', scopes: ['source.python', 'meta.function.inline.python', 'meta.function.inline.parameters.python', 'punctuation.separator.parameters.python']
-    expect(tokens[5]).toEqual value: 'z', scopes: ['source.python', 'meta.function.inline.python', 'meta.function.inline.parameters.python', 'variable.parameter.function.python']
-    expect(tokens[7]).toEqual value: '=', scopes: ['source.python', 'meta.function.inline.python', 'meta.function.inline.parameters.python', 'keyword.operator.assignment.python']
-    expect(tokens[9]).toEqual value: '4', scopes: ['source.python', 'meta.function.inline.python', 'meta.function.inline.parameters.python', 'constant.numeric.integer.decimal.python']
-    expect(tokens[10]).toEqual value: ':', scopes: ['source.python', 'meta.function.inline.python', 'punctuation.definition.function.begin.python']
-    expect(tokens[11]).toEqual value: ' x ', scopes: ['source.python']
-
   # Add the grammar test fixtures
   grammarTest path.join(__dirname, 'fixtures/grammar/syntax_test_python.py')
+  grammarTest path.join(__dirname, 'fixtures/grammar/syntax_test_python_lambdas.py')
   grammarTest path.join(__dirname, 'fixtures/grammar/syntax_test_python_typing.py')
 
   describe "SQL highlighting", ->


### PR DESCRIPTION
### Description of the Change

Introduce syntax tests to improve the test coverage.  Anticipating changes for the tree-sitter migration (cc @maxbrunsfeld + @ambv), we'd benefit from having a more complete set of grammar tests to ensure compatibility.  This begins developing those test fixtures.

This introduces a few syntax fixture files and fixes a bug with missing vararg and kwarg syntax highlighting.

### Benefits

[atom-grammar-test](https://github.com/kevinastone/atom-grammar-test) is a test helper to allow you to provide code snippets and examples that you annotate with the desired syntax rules.  It makes it much easier to validate the grammar rules and allows parties to provide examples of missing of errant syntax highlighting.

### Possible Drawbacks

Dependency on another package?  It's been used by several atom language grammars to date.

### Applicable Issues

N/A