### PR TITLE
add more test cases for lambda tokenization

### DIFF
--- a/grammars/python.cson
+++ b/grammars/python.cson
@@ -335,7 +335,7 @@
     ]
   }
   {
-    'begin': '\\b(lambda)\\s?+'
+    'begin': '\\b(lambda)(?=[\\s\\:])'
     'beginCaptures':
       '1':
         'name': 'storage.type.function.inline.python'

--- a/grammars/python.cson
+++ b/grammars/python.cson
@@ -335,7 +335,7 @@
     ]
   }
   {
-    'begin': '\\b(lambda)(?=[\\s\\:])'
+    'begin': '\\b(lambda)\\b'
     'beginCaptures':
       '1':
         'name': 'storage.type.function.inline.python'

--- a/spec/python-spec.coffee
+++ b/spec/python-spec.coffee
@@ -721,7 +721,6 @@ describe "Python grammar", ->
     {tokens} = grammar.tokenizeLine "lambda x, z = 4: x * z"
 
     expect(tokens[0]).toEqual value: 'lambda', scopes: ['source.python', 'meta.function.inline.python', 'storage.type.function.inline.python']
-    expect(tokens[1]).toEqual value: ' ', scopes: ['source.python', 'meta.function.inline.python']
     expect(tokens[2]).toEqual value: 'x', scopes: ['source.python', 'meta.function.inline.python', 'meta.function.inline.parameters.python', 'variable.parameter.function.python']
     expect(tokens[3]).toEqual value: ',', scopes: ['source.python', 'meta.function.inline.python', 'meta.function.inline.parameters.python', 'punctuation.separator.parameters.python']
     expect(tokens[5]).toEqual value: 'z', scopes: ['source.python', 'meta.function.inline.python', 'meta.function.inline.parameters.python', 'variable.parameter.function.python']
@@ -735,9 +734,13 @@ describe "Python grammar", ->
     expect(tokens[0]).toEqual value: 'lambda', scopes: ['source.python', 'meta.function.inline.python', 'storage.type.function.inline.python']
     expect(tokens[1]).toEqual value: ':', scopes: ['source.python', 'meta.function.inline.python', 'punctuation.definition.function.begin.python']
 
-  it "does not tokenizes a variable name containing lambda as a lambda", ->
+  it "does not tokenizes a variable name ending with lambda as a lambda", ->
     {tokens} = grammar.tokenizeLine "not_a_lambda.foo"
     expect(tokens[0]).toEqual value: 'not_a_lambda', scopes: ['source.python', 'variable.other.object.python']
+
+  it "does not tokenizes a variable name starting with lambda as a lambda", ->
+    {tokens} = grammar.tokenizeLine "lambda_not.foo"
+    expect(tokens[0]).toEqual value: 'lambda_not', scopes: ['source.python', 'variable.other.object.python']
 
   describe "SQL highlighting", ->
     beforeEach ->


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change
Matches `lambda` via lookahead for whitespace or `:`. This resolves #246 and a problem introduced in #253 

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

#253 broke parsing `lambda_not.foo`. This fixes it while preserving correct tokenization for #246 