### PR TITLE
'lcie' prefix was 'else condition' when it should have been 'else value'

### DIFF
--- a/snippets/language-python.cson
+++ b/snippets/language-python.cson
@@ -94,7 +94,7 @@
     'body': '[${1:value} for ${2:value} in ${3:variable}]'
   'List Comprehension If Else':
     'prefix': 'lcie'
-    'body': '[${1:value} if ${2:condition} else ${3:condition} for ${4:value} in ${5:variable}]'
+    'body': '[${1:value} if ${2:condition} else ${3:value} for ${4:value} in ${5:variable}]'
   'Dictionary Comprehension':
     'prefix': 'dc'
     'body': '{${1:key}: ${2:value} for ${3:key}, ${4:value} in ${5:variable}}'


### PR DESCRIPTION
### Description of the Change

Currently when you type in lcie to autocomplete a list comprehension if else it autocompletes it to '[value if condition else condition for value in variable]'. But it should actually be '[value if condition else value for value in variable]' since you are specifying an alternative value after the 'else' and not specifying another condition.

### Alternate Designs

There are not any other reasonable ways to make this change.

### Benefits

The list comprehension if else auto-completion will be clearer.

### Possible Drawbacks

None

### Applicable Issues

None
