### PR TITLE
Add missing keywords to tree-sitter-python

### DIFF
--- a/grammars/tree-sitter-python.cson
+++ b/grammars/tree-sitter-python.cson
@@ -75,6 +75,9 @@ scopes:
   '"def"': 'storage.type.function'
   '"lambda"': 'storage.type.function'
 
+  '"global"': 'storage.modifier.global'
+  '"nonlocal"': 'storage.modifier.nonlocal'
+
   '"if"': 'keyword.control'
   '"else"': 'keyword.control'
   '"elif"': 'keyword.control'
@@ -83,6 +86,7 @@ scopes:
   '"return"': 'keyword.control'
   '"break"': 'keyword.control'
   '"continue"': 'keyword.control'
+  '"pass"': 'keyword.control'
   '"raise"': 'keyword.control'
   '"yield"': 'keyword.control'
   '"await"': 'keyword.control'
@@ -94,8 +98,11 @@ scopes:
   '"finally"': 'keyword.control'
   '"import"': 'keyword.control'
   '"from"': 'keyword.control'
-  '"print"': 'keyword.control'
-  '"assert"': 'keyword.control'
+
+  '"print"': 'keyword.other'
+  '"assert"': 'keyword.other'
+  '"exec"': 'keyword.other'
+  '"del"': 'keyword.other'
 
   '"+"': 'keyword.operator'
   '"-"': 'keyword.operator'


### PR DESCRIPTION
I added some missing keywords (`global`, `nonlocal`, `exec`, `del`). I changed the scope of `print` and `assert` from `keyword.control` to `keyword.other`, so that they have the same scope as `exec` and `del`. This is more consistent with the scopes in `python.cson`.