### PR TITLE
Please remove snippet config for 'self'

### DIFF
--- a/snippets/language-python.cson
+++ b/snippets/language-python.cson
@@ -119,7 +119,3 @@
   'if __name__ == \'__main__\'':
     'prefix': 'ifmain'
     'body': 'if __name__ == \'__main__\':\n\t${1:main()}$0'
-'.source.python:not(.string)':
-  'self':
-    'prefix': '.'
-    'body': 'self.'


### PR DESCRIPTION
Fixes #261 
Fixes #154

### Description of the Change

I removed this snippet:
```
'.source.python:not(.string)':
  'self':
    'prefix': '.'
    'body': 'self.'
```
-->

### Alternate Designs

I considered retooling the snippet so that there was still a way for 'self' to be auto-populated in some fashion, but ultimately reasoned that the time saved from not having to type four characters is not worth the time lost having it populated accidentally.

### Benefits

People will be more likely to use Atom to write their Python scrips.  With the current code, 'self' is injected at almost every use of '.'  Which, as you can imagine, becomes burdensome, especially since it also applies to text written in comments.

### Possible Drawbacks

Some people may be using this feature and they may be annoyed to see it go.

I personally believe that more people would welcome the change than be irritated by the change.
