### PR TITLE
Add foldEndPattern to settings

### DIFF
--- a/settings/language-python.cson
+++ b/settings/language-python.cson
@@ -4,5 +4,6 @@
     'softTabs': true
     'tabLength': 4
     'commentStart': '# '
+    'foldEndPattern': '^\\s*\\}|^\\s*\\]|^\\s*\\)'
     'increaseIndentPattern': '^\\s*(class|def|elif|else|except|finally|for|if|try|with|while|async\\s+(def|for|with))\\b.*:\\s*$'
     'decreaseIndentPattern': '^\\s*(elif|else|except|finally)\\b.*:\\s*$'

--- a/settings/language-python.cson
+++ b/settings/language-python.cson
@@ -4,6 +4,6 @@
     'softTabs': true
     'tabLength': 4
     'commentStart': '# '
-    'foldEndPattern': '^\\s*\\}|^\\s*\\]|^\\s*\\)'
+    'foldEndPattern': '^\\s*[}\\])]'
     'increaseIndentPattern': '^\\s*(class|def|elif|else|except|finally|for|if|try|with|while|async\\s+(def|for|with))\\b.*:\\s*$'
     'decreaseIndentPattern': '^\\s*(elif|else|except|finally)\\b.*:\\s*$'


### PR DESCRIPTION
### Description of the Change

Add a value for `foldEndPattern` in the package settings. This improves the folding behavior for dictionaries, lists, and functions when not using the tree-sitter parser. It folds the entire logical syntax item instead of leaving the ending character on a separate line. It also improves the use of [Hydrogen](https://atom.io/packages/Hydrogen) when the ending `}`, `)`, or `]` is on a separate line and not indented.

Many other core Atom language grammars have a `foldEndPattern`; the regex used in this PR is taken from [`language-javascript`](https://github.com/atom/language-javascript/blob/df7a049ec5b6e866b1686c561ba8d8bb7c0de0c5/settings/language-javascript.cson#L5) because of the similarity in syntax used for data structures.

### Alternate Designs

The regex is `^\\s*\\}|^\\s*\\]|^\\s*\\)` in order to fold the end of dictionaries, lists, and functions/tuples, respectively.

At first thought, it might be desirable to add `^\\s*"""` to the regex in order to fold multi-line strings, but since the same characters are used to open a multiline   string, this can create bugs. In fact, this [used to be the value](https://github.com/atom/language-python/pull/155) of `foldEndPattern` in this package, but was removed upon [unintended](https://github.com/nteract/hydrogen/issues/418) [effects](https://github.com/atom/atom/issues/12533) used with Hydrogen.

### Benefits

1. Improve fold behavior by including the ending character (see screenshots below)

**Expanded**:
![image](https://user-images.githubusercontent.com/15164633/45392246-71299b80-b5f4-11e8-9f23-364da0a26b8c.png)

**Current fold behavior**:
![image](https://user-images.githubusercontent.com/15164633/45392284-a8984800-b5f4-11e8-8484-f91897382c85.png)

**New fold behavior**:
![image](https://user-images.githubusercontent.com/15164633/45392258-81417b00-b5f4-11e8-996f-71efdf30a178.png)

2. This would also improve behavior with the [Hydrogen](https://atom.io/packages/Hydrogen) package, as that uses Atom's fold regions to decide what block of code to send to the Jupyter kernel. A hacky solution to this was developed (https://github.com/nikitakit/hydrogen-python/pull/10, [code](https://github.com/nikitakit/hydrogen-python/pull/10/files#diff-16b7d75b70953cbf4755508170f2f24cR58)) in a Python-specific extension to Hydrogen, but the plugin's use is not widespread among all Hydrogen Python users.

**Current Hydrogen behavior with ending character on separate line**:
![image](https://user-images.githubusercontent.com/15164633/45392861-4260f480-b5f7-11e8-9120-ba292bcd707e.png)

**New Hydrogen behavior with ending character on separate line**:

![image](https://user-images.githubusercontent.com/15164633/45392910-818f4580-b5f7-11e8-8d02-e05ff1f06974.png)

### Possible Drawbacks

Those who prefer the current behavior could be disappointed? I can't think of any others.

### Applicable Issues

- https://github.com/MagicStack/MagicPython/issues/80
- https://github.com/nteract/hydrogen/issues/724
- https://github.com/nteract/hydrogen/issues/155
