### PR TITLE
Escape regex properly

### DIFF
--- a/grammars/regular expressions (python).cson
+++ b/grammars/regular expressions (python).cson
@@ -15,6 +15,10 @@
     'name': 'keyword.other.back-reference.regexp'
   }
   {
+    'match': '\\\\.'
+    'name': 'constant.character.escape.backslash.regexp'
+  }
+  {
     'match': '[?+*][?+]?|\\{(\\d+,\\d+|\\d+,|,\\d+|\\d+)\\}\\??'
     'name': 'keyword.operator.quantifier.regexp'
   }

--- a/spec/python-regex-spec.coffee
+++ b/spec/python-regex-spec.coffee
@@ -30,3 +30,23 @@ describe 'Python regular expression grammar', ->
       expect(tokens[1]).toEqual value: '^', scopes: ['source.regexp.python', 'constant.other.character-class.set.regexp', 'keyword.operator.negation.regexp']
       expect(tokens[2]).toEqual value: '][', scopes: ['source.regexp.python', 'constant.other.character-class.set.regexp']
       expect(tokens[3]).toEqual value: ']', scopes: ['source.regexp.python', 'constant.other.character-class.set.regexp', 'punctuation.definition.character-class.end.regexp']
+
+    it 'escapes the character following any backslash', ->
+      {tokens} = grammar.tokenizeLine '''\\q\\(\\[\\'\\"\\?\\^\\-\\*\\.\\#'''
+      expect(tokens[0]).toEqual value: '\\q', scopes: ['source.regexp.python', 'constant.character.escape.backslash.regexp']
+      expect(tokens[1]).toEqual value: '\\(', scopes: ['source.regexp.python', 'constant.character.escape.backslash.regexp']
+      expect(tokens[2]).toEqual value: '\\[', scopes: ['source.regexp.python', 'constant.character.escape.backslash.regexp']
+      expect(tokens[3]).toEqual value: '\\\'', scopes: ['source.regexp.python', 'constant.character.escape.backslash.regexp']
+      expect(tokens[4]).toEqual value: '\\"', scopes: ['source.regexp.python', 'constant.character.escape.backslash.regexp']
+      expect(tokens[5]).toEqual value: '\\?', scopes: ['source.regexp.python', 'constant.character.escape.backslash.regexp']
+      expect(tokens[6]).toEqual value: '\\^', scopes: ['source.regexp.python', 'constant.character.escape.backslash.regexp']
+      expect(tokens[7]).toEqual value: '\\-', scopes: ['source.regexp.python', 'constant.character.escape.backslash.regexp']
+      expect(tokens[8]).toEqual value: '\\*', scopes: ['source.regexp.python', 'constant.character.escape.backslash.regexp']
+      expect(tokens[9]).toEqual value: '\\.', scopes: ['source.regexp.python', 'constant.character.escape.backslash.regexp']
+      expect(tokens[10]).toEqual value: '\\#', scopes: ['source.regexp.python', 'constant.character.escape.backslash.regexp']
+
+      {tokens} = grammar.tokenizeLine '''(\\()\\)'''
+      expect(tokens[0]).toEqual value: '(', scopes: ['source.regexp.python', 'meta.group.regexp', 'punctuation.definition.group.regexp']
+      expect(tokens[1]).toEqual value: '\\(', scopes: ['source.regexp.python', 'meta.group.regexp', 'constant.character.escape.backslash.regexp']
+      expect(tokens[2]).toEqual value: ')', scopes: ['source.regexp.python', 'meta.group.regexp', 'punctuation.definition.group.regexp']
+      expect(tokens[3]).toEqual value: '\\)', scopes: ['source.regexp.python', 'constant.character.escape.backslash.regexp']


### PR DESCRIPTION
### Description of the Change

Add in escape rule, so we don't get false positives for groups, etc.

### Alternate Designs

I could have tried finding all proper escapable characters, but that's difficult. My experiments with regex101.com indicate escaping any character will count as an escape, in some way or another (e.g., `\q` means a literal `q`).

### Benefits

No more leaking regex when opening parentheses are supposed to be escaped

### Possible Drawbacks

Unicode escapes are more complicated, but I believe they are not supported at all currently. This will not break them.

### Applicable Issues

Fixes https://github.com/atom/language-python/issues/259
