### PR TITLE
Scope built in functions as support.function

### DIFF
--- a/grammars/tree-sitter-python.cson
+++ b/grammars/tree-sitter-python.cson
@@ -67,7 +67,11 @@ scopes:
 
   'class_definition > identifier': 'entity.name.type.class'
   'function_definition > identifier': 'entity.name.function'
-  'call > identifier:nth-child(0)': 'entity.name.function'
+  'call > identifier:nth-child(0)': [
+    {match: '^(abs|all|any|ascii|bin|bool|breakpoint|bytearray|bytes|callable|chr|classmethod|compile|complex|delattr|dict|dir|divmod|enumerate|eval|exec|filter|float|format|frozenset|getattr|globals|hasattr|hash|help|hex|id|input|int|isinstance|issubclass|iter|len|list|locals|map|max|memoryview|min|next|object|oct|open|ord|pow|print|property|range|repr|reversed|round|set|setattr|slice|sorted|staticmethod|str|sum|super|tuple|type|vars|zip|__import__)$',
+    scopes: 'support.function'},
+    'entity.name.function'
+   ]
   'call > attribute > identifier:nth-child(2)': 'entity.name.function'
 
   'attribute > identifier:nth-child(2)': 'variable.other.object.property'


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Scopes built in python functions as `support.function`. Textmate scoped these as `support.function.builtin.python`.

https://github.com/atom/language-python/issues/286 reported that `print` is no longer scoped as `keyword.other`. Textmate always scoped `print` and `exec` as `keyword.other` even when they were used as a function. In Python 3 these keywords were removed and `print` and `exec` are built in functions.

This PR fixes https://github.com/atom/language-python/issues/286 by scoping all built in functions as `support.function`.

Function list taken from https://docs.python.org/3/library/functions.html

### Alternate Designs

* Don't scope built in functions separately
* Incorrectly scope `print` and `exec` as a keyword to match textmate

### Benefits

* Built in functions are scoped the same as textmate
* Correctly scopes `print` and `exec` as functions except when used as a keyword (python2)

### Applicable Issues

Fixes https://github.com/atom/language-python/issues/286

/cc: @maxbrunsfeld 