### PR TITLE
Add more scopes to the tree sitter grammar

### DIFF
--- a/grammars/tree-sitter-python.cson
+++ b/grammars/tree-sitter-python.cson
@@ -74,6 +74,11 @@ scopes:
    ]
   'call > attribute > identifier:nth-child(2)': 'entity.name.function'
 
+  'identifier':
+    {match:
+      '^(BaseException|Exception|TypeError|StopAsyncIteration|StopIteration|ImportError|ModuleNotFoundError|OSError|ConnectionError|BrokenPipeError|ConnectionAbortedError|ConnectionRefusedError|ConnectionResetError|BlockingIOError|ChildProcessError|FileExistsError|FileNotFoundError|IsADirectoryError|NotADirectoryError|InterruptedError|PermissionError|ProcessLookupError|TimeoutError|EOFError|RuntimeError|RecursionError|NotImplementedError|NameError|UnboundLocalError|AttributeError|SyntaxError|IndentationError|TabError|LookupError|IndexError|KeyError|ValueError|UnicodeError|UnicodeEncodeError|UnicodeDecodeError|UnicodeTranslateError|AssertionError|ArithmeticError|FloatingPointError|OverflowError|ZeroDivisionError|SystemError|ReferenceError|BufferError|MemoryError|Warning|UserWarning|DeprecationWarning|PendingDeprecationWarning|SyntaxWarning|RuntimeWarning|FutureWarning|ImportWarning|UnicodeWarning|BytesWarning|ResourceWarning|GeneratorExit|SystemExit|KeyboardInterrupt)$'
+    scopes: 'support.type.exception'}
+
   'attribute > identifier:nth-child(2)': 'variable.other.object.property'
 
   'decorator': 'entity.name.function.decorator'
@@ -81,8 +86,8 @@ scopes:
   'none': 'constant.language'
   'true': 'constant.language'
   'false': 'constant.language'
-  'integer': 'constant.language'
-  'float': 'constant.language'
+  'integer': 'constant.numeric'
+  'float': 'constant.numeric'
 
   'type > identifier': 'support.storage.type'
 
@@ -149,6 +154,8 @@ scopes:
   '"~"': 'keyword.operator'
   '"<<"': 'keyword.operator'
   '">>"': 'keyword.operator'
+  'binary_operator > "@"': 'keyword.operator'
+  'binary_operator > "@="': 'keyword.operator'
   '"in"': 'keyword.operator.logical.python'
   '"and"': 'keyword.operator.logical.python'
   '"or"': 'keyword.operator.logical.python'


### PR DESCRIPTION
#### Description

This PR adds the suggested changes from https://github.com/atom/language-python/pull/257 using the latest tree-sitter-python and API.

We are using:
`'binary_operator > "@"': 'keyword.operator'`

To avoid highlighting the `@` in `decorated_definition > decorator > "@"` as `keyword.operator` in f.ex.:
```python
@classmethod
def foo(*, arg1,arg2):
    ...
```

#### Open questions
1. When raising exception using the `raise Exception('a')` syntax. The exception is scoped as a function call (`entity.name.function`). Should `Exception` be `support.type.exception` in this case as well?
```python
        raise ValueError('A very specific bad thing happened.')
```
2. Compared to https://github.com/atom/language-python/pull/257 we are missing two functions:
`__build_class__`
`BuiltinImporter`

I used the list from https://docs.python.org/3/library/functions.html when adding [the current functions](https://github.com/atom/language-python/commit/38dd8484267376001da0d117a73e301d4e52705e#diff-66ebbdbcf9a0e7a97d0f213cb23ca8e6R71). Are these two functions and should be added?

#### Issues
Supersedes and closes https://github.com/atom/language-python/pull/257
Fixes https://github.com/atom/language-python/issues/295

/cc @ambv @maxbrunsfeld 