### PR TITLE
Fix codestyle E301 in class snippet

### DIFF
--- a/snippets/language-python.cson
+++ b/snippets/language-python.cson
@@ -55,7 +55,7 @@
     'body': 'self.fail(\'${1:message}\')$0'
   'New Class':
     'prefix': 'class'
-    'body': 'class ${1:ClassName}(${2:object}):\n\t"""${3:docstring for $1.}"""\n\tdef __init__(self, ${4:arg}):\n\t\t${5:super($1, self).__init__()}\n\t\tself.arg = arg\n\t\t$0'
+    'body': 'class ${1:ClassName}(${2:object}):\n\t"""${3:docstring for $1.}"""\n\n\tdef __init__(self, ${4:arg}):\n\t\t${5:super($1, self).__init__()}\n\t\tself.arg = arg\n\t\t$0'
   'New Method':
     'prefix': 'defs'
     'body': 'def ${1:mname}(self, ${2:arg}):\n\t${3:pass}'


### PR DESCRIPTION
### Description of the Change

Added a newline after the docstring of the new class snippet. This is required to respect E301.

### Alternate Designs

None

### Benefits

Valid codestyle

### Possible Drawbacks

None

### Applicable Issues

-
