### PR TITLE
Fix code folding for 'elif' and 'else' statements

### DIFF
--- a/grammars/tree-sitter-python.cson
+++ b/grammars/tree-sitter-python.cson
@@ -27,7 +27,8 @@ fileTypes: [
 folds: [
   {
     type: [
-      'if_statement'
+      'elif_clause'
+      'else_clause'
       'for_statement'
       'try_statement'
       'with_statement'
@@ -37,6 +38,11 @@ folds: [
       'async_function_definition'
     ]
     start: {type: ':'}
+  },
+  {
+    type: ['if_statement']
+    start: {type: ':'}
+    end: {type: ['elif_clause', 'else_clause']}
   }
   {
     start: {type: '(', index: 0}


### PR DESCRIPTION
### Description of the Change

This PR fixes #290 which reports that the Tree-Sitter Python grammar does not fold `elif` and `else` correctly.  The fix is to update `tree-sitter-python.cson` to be a little more explicit about the nodes that cause `if_statement` folding to end.

**Before**

![python_folding_broken](https://user-images.githubusercontent.com/79405/52314163-47d42800-2966-11e9-9c1f-cc0f87807b01.png)


**After**

![python_folding_fixed](https://user-images.githubusercontent.com/79405/52314036-a947c700-2965-11e9-850d-b1108829d9ca.png)

### Alternate Designs

None.

### Benefits

`elif` and `else` blocks fold as expected.

### Possible Drawbacks

None?

### Applicable Issues

Fixes #290
