### PR TITLE
Add support for python2/3 shebangs in tree-sitter grammar

### DIFF
--- a/grammars/tree-sitter-python.cson
+++ b/grammars/tree-sitter-python.cson
@@ -5,7 +5,7 @@ parser: 'tree-sitter-python'
 
 firstLineRegex: [
   # shebang line
-  '^#!.*\\b(python)\\r?\\n'
+  '^#![ \\t]*/.*\\bpython[\\d\\.]*\\b'
 
   # vim modeline
   'vim\\b.*\\bset\\b.*\\b(filetype|ft|syntax)=python'


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

I add shebang lines atop all my Python files. If I use `#!/usr/bin/python` or `#!/usr/bin/env python`, the buffer will use the Python tree-sitter grammar (instead of first-mate). However, if I use `#!/usr/bin/env python2` or `#!/usr/bin/env python3`, the tree-sitter grammar is always ignored (in favor of first-mate).

This PR updates the `firstLineRegex` field in the tree-sitter grammar to exactly match what's in the first-mate grammar. As a result, `.py` files with a `python2` or `python3` shebang now use the `tree-sitter` grammar (if tree-sitter is enabled in Atom, of course).

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

The tree-sitter `firstLineRegex` could've been rewritten to not be quite as lenient as the first-mate equivalent, but I didn't feel this was a major concern. The current first-mate regex is simple and understandable enough as-is.

### Benefits

<!-- What benefits will be realized by the code change? -->

Consistent syntax highlighting and the benefits of tree-sitter across more types of Python files (i.e. with or without the "versioned" shebang).

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

I know the tree-sitter grammar still lacks some highlighting compared to the first-mate grammar, which may make it undesirable to apply more broadly. I plan to submit a few more PRs soon to resolve some of these issues (e.g. tokenizing function parameter names). However, I still think the tree-sitter grammar, for all of its benefits, is worthy of adopting more broadly despite these minor issues (at least those few I've noticed).

### Applicable Issues

<!-- Enter any applicable Issues here -->

N/A