### PR TITLE
Tokenize formal function parameters in tree-sitter grammar

### DIFF
--- a/grammars/tree-sitter-python.cson
+++ b/grammars/tree-sitter-python.cson
@@ -99,6 +99,8 @@ scopes:
   '"global"': 'storage.modifier.global'
   '"nonlocal"': 'storage.modifier.nonlocal'
 
+  'parameters > identifier': 'variable.parameter.function'
+  'default_parameter > identifier:nth-child(0)': 'variable.parameter.function'
   'keyword_argument > identifier:nth-child(0)': 'variable.parameter.function'
 
   '"if"': 'keyword.control'


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

This PR tokenizes the formal function parameters in the `tree-sitter` grammar:

**Before:**  
<img width="659" alt="Screen Shot 2019-04-06 at 1 37 55 PM" src="https://user-images.githubusercontent.com/872474/55675083-2adaa900-5872-11e9-9b88-832150b192d9.png">

**After:**  
<img width="667" alt="Screen Shot 2019-04-06 at 1 38 22 PM" src="https://user-images.githubusercontent.com/872474/55675087-35953e00-5872-11e9-8252-c7a4a74d6e47.png">

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->
I don't know if the core Atom team would prefer to use a different scope to tokenize these formal function parameters. However, the `variable.parameter.function` scope is already used to tokenize keyword arguments in the tree-sitter grammar, so I don't think there's any inconsistency here.

### Benefits

<!-- What benefits will be realized by the code change? -->

Better highlighting for the formal function parameters in Python files matched by the tree-sitter grammar. This matches the highlighting in the existing first-mate grammar.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

None that I can see.

### Applicable Issues

<!-- Enter any applicable Issues here -->
N/A