### PR TITLE
Tokenize subclass list names in tree-sitter grammar

### DIFF
--- a/grammars/tree-sitter-python.cson
+++ b/grammars/tree-sitter-python.cson
@@ -92,6 +92,11 @@ scopes:
 
   'type > identifier': 'support.storage.type'
 
+  'class_definition > argument_list > attribute': 'entity.other.inherited-class'
+  'class_definition > argument_list > identifier': 'entity.other.inherited-class'
+  'class_definition > argument_list > keyword_argument > attribute': 'entity.other.inherited-class'
+  'class_definition > argument_list > keyword_argument > identifier:nth-child(2)': 'entity.other.inherited-class'
+
   '"class"': 'storage.type.class'
   '"def"': 'storage.type.function'
   '"lambda"': 'storage.type.function'


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

This PR tokenizes the names of subclasses listed within class definitions, for Python files matched by the tree-sitter grammar.

**Before:**  
<img width="709" alt="Screen Shot 2019-04-06 at 2 09 32 PM" src="https://user-images.githubusercontent.com/872474/55675340-e8b36680-5875-11e9-9f17-79b46cf87b1e.png">

**After:**  
<img width="704" alt="Screen Shot 2019-04-06 at 2 10 30 PM" src="https://user-images.githubusercontent.com/872474/55675342-ee10b100-5875-11e9-8027-f7f41f1e45b4.png">

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

I don't know if the Atom team desires to tokenize these subclass names differently; I figured `entity.other.inherited-class` was the most appropriate scope, as it's based on the same scope from the first-mate grammar.

### Benefits

<!-- What benefits will be realized by the code change? -->

Syntax highlighting that is more familiar to longtime users of the Python first-mate grammar.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

Perhaps some might prefer different colors be used for the subclass names, though I personalli like them.

### Applicable Issues

<!-- Enter any applicable Issues here -->

N/A