### PR TITLE
Allow folding if statement without elif or else

### DIFF
--- a/grammars/tree-sitter-python.cson
+++ b/grammars/tree-sitter-python.cson
@@ -26,7 +26,13 @@ fileTypes: [
 
 folds: [
   {
+    type: ['if_statement']
+    start: {type: ':'}
+    end: {type: ['elif_clause', 'else_clause']}
+  },
+  {
     type: [
+      'if_statement'
       'elif_clause'
       'else_clause'
       'for_statement'
@@ -39,11 +45,6 @@ folds: [
     ]
     start: {type: ':'}
   },
-  {
-    type: ['if_statement']
-    start: {type: ':'}
-    end: {type: ['elif_clause', 'else_clause']}
-  }
   {
     start: {type: '(', index: 0}
     end: {type: ')', index: -1}


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

The changes introduced in https://github.com/atom/language-python/pull/292 made it impossible to fold an `if_statement` without an `elif_clause` and/or `else_clause`. This PR fixes this by adding back `if_statement` to the fold rules and rearranges the rules so the rule that ends with `elif_clause` and `else_clause` types take precedence.

***Before:***
![image](https://user-images.githubusercontent.com/1058982/55982125-8228b100-5c98-11e9-9798-301e2a217dfd.png)

***After:***
![image](https://user-images.githubusercontent.com/1058982/55982144-8f45a000-5c98-11e9-86c0-cb1721de50a9.png)


### Alternate Designs

No

### Benefits

Can fold lonely if statements again

### Possible Drawbacks

No

### Applicable Issues

Folding part of https://github.com/atom/language-python/issues/299

/cc: @daviwil FYI
