### PR TITLE
Tokenize *args and **kwargs the same as other parameters (tree-sitter)

### DIFF
--- a/grammars/tree-sitter-python.cson
+++ b/grammars/tree-sitter-python.cson
@@ -111,6 +111,8 @@ scopes:
   '"nonlocal"': 'storage.modifier.nonlocal'
 
   'parameters > identifier': 'variable.parameter.function'
+  'parameters > list_splat > identifier': 'variable.parameter.function'
+  'parameters > dictionary_splat > identifier': 'variable.parameter.function'
   'default_parameter > identifier:nth-child(0)': 'variable.parameter.function'
   'keyword_argument > identifier:nth-child(0)': 'variable.parameter.function'
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Back in https://github.com/atom/language-python/pull/297, I added highlighting for formal function parameters to the Python tree-sitter grammar. This PR follows up on that work with two additional fixes for splat parameters such as `*args` and `**kwargs`.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

I could've chosen more-generic or more-specific selectors to tokenize these nodes, depending on how broad these changes are desired to be. But to avoid any potential breakages, I aimed to keep these changes narrow in scope.

**Before:**  
<img width="499" alt="Before" src="https://user-images.githubusercontent.com/872474/57589014-70723d80-74d2-11e9-8790-cbac4d58251b.png">

**After:**  
<img width="496" alt="After" src="https://user-images.githubusercontent.com/872474/57589015-76681e80-74d2-11e9-9a42-585c7a945672.png">


### Benefits

<!-- What benefits will be realized by the code change? -->

More consistent syntax highlighting for tree-sitter-tokenized Python files, continuing in the spirit of https://github.com/atom/language-python/pull/297

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

I don't think there are any, as I tried to make my changes focused enough to avoid breaking anything. But if there's anything else I could consider in terms of the impact on Python syntax, please let me know!

### Applicable Issues

<!-- Enter any applicable Issues here -->
https://github.com/atom/language-python/pull/297 (already merged by @nathansobo)
