### PR TITLE
Add injectionRegex to the tree-sitter grammar

### DIFF
--- a/grammars/tree-sitter-python.cson
+++ b/grammars/tree-sitter-python.cson
@@ -24,6 +24,8 @@ fileTypes: [
   'wsgi'
 ]
 
+injectionRegex: '^py$|python|Python'
+
 folds: [
   {
     type: ['if_statement']


### PR DESCRIPTION
This allows to use this grammar from other tree-sitter grammars.

See also: https://github.com/atom/atom/pull/17551

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This change adds `injectionRegex` regex key into `tree-sitter-python.cson`. Other grammars will be able to inject python grammar by specifying language `py` or anything that contains `Python` or `python`.

### Alternate Designs

I don't know about any other alternatives.

### Benefits

This will allow to use python grammar from other language packages that use tree-sitter. I'm developing https://github.com/eugmes/language-coccinelle that will benefit from this feature. 

### Possible Drawbacks

The grammar can be injected instead of some other grammar that uses similar injection regex. But I think that the proposed regex is specific enough to not cause many problems.

### Applicable Issues

None?
