### PR TITLE
Add a lookahead for DELETE to avoid mistaking HTTP strings for SQL

### DIFF
--- a/grammars/python.cson
+++ b/grammars/python.cson
@@ -1643,7 +1643,7 @@
         'name': 'string.quoted.double.block.python'
         'patterns': [
           {
-             'begin': '(?=\\s*(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER|WITH))'
+             'begin': '(?=\\s*(SELECT|INSERT|UPDATE|DELETE(?! \/)|CREATE|REPLACE|ALTER|WITH))'
              'name': 'meta.embedded.sql'
              'end': '(?=\\s*""")'
              'patterns': [
@@ -1655,7 +1655,7 @@
         ]
       }
       {
-        'begin': '(")(?=\\s*(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER|WITH))'
+        'begin': '(")(?=\\s*(SELECT|INSERT|UPDATE|DELETE(?! \/)|CREATE|REPLACE|ALTER|WITH))'
         'beginCaptures':
           '1':
             'name': 'punctuation.definition.string.begin.python'
@@ -2214,7 +2214,7 @@
         'name': 'string.quoted.single.block.python'
         'patterns': [
           {
-             'begin': '(?=\\s*(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER|WITH))'
+             'begin': '(?=\\s*(SELECT|INSERT|UPDATE|DELETE(?! \/)|CREATE|REPLACE|ALTER|WITH))'
              'end': '(?=\\s*\'\'\')'
              'name': 'meta.embedded.sql'
              'patterns': [
@@ -2226,7 +2226,7 @@
         ]
       }
       {
-        'begin': '(\')(?=\\s*(SELECT|INSERT|UPDATE|DELETE|CREATE|REPLACE|ALTER|WITH))'
+        'begin': '(\')(?=\\s*(SELECT|INSERT|UPDATE|DELETE(?! \/)|CREATE|REPLACE|ALTER|WITH))'
         'beginCaptures':
           '1':
             'name': 'punctuation.definition.string.begin.python'

--- a/spec/python-spec.coffee
+++ b/spec/python-spec.coffee
@@ -754,6 +754,6 @@ describe "Python grammar", ->
     it "recognizes DELETE as an HTTP method", ->
       {tokens} = grammar.tokenizeLine('"DELETE /api/v1/endpoint"')
 
-      expect(tokens[0]).toEqual value: '"', scopes: ['source.python', 'string.quoted.single.single-line.python', 'punctuation.definition.string.begin.python']
-      expect(tokens[1]).toEqual value: 'DELETE /api/v1/endpoint', scopes: ['source.python', 'string.quoted.single.single-line.python']
-      expect(tokens[2]).toEqual value: '"', scopes: ['source.python', 'string.quoted.single.single-line.python', 'punctuation.definition.string.end.python']
+      expect(tokens[0]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.begin.python']
+      expect(tokens[1]).toEqual value: 'DELETE /api/v1/endpoint', scopes: ['source.python', 'string.quoted.double.single-line.python']
+      expect(tokens[2]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.python', 'punctuation.definition.string.end.python']

--- a/spec/python-spec.coffee
+++ b/spec/python-spec.coffee
@@ -750,3 +750,10 @@ describe "Python grammar", ->
       expect(tokens[13]).toEqual value: ')', scopes: ['source.python', 'string.quoted.double.single-line.sql.python', 'meta.embedded.sql', 'punctuation.definition.section.bracket.round.end.sql']
       expect(tokens[15]).toEqual value: '"', scopes: ['source.python', 'string.quoted.double.single-line.sql.python', 'punctuation.definition.string.end.python']
       expect(tokens[17]).toEqual value: '%', scopes: ['source.python', 'keyword.operator.arithmetic.python']
+
+    it "recognizes DELETE as an HTTP method", ->
+      {tokens} = grammar.tokenizeLine('"DELETE /api/v1/endpoint"')
+
+      expect(tokens[0]).toEqual value: '"', scopes: ['source.python', 'string.quoted.single.single-line.python', 'punctuation.definition.string.begin.python']
+      expect(tokens[1]).toEqual value: 'DELETE /api/v1/endpoint', scopes: ['source.python', 'string.quoted.single.single-line.python']
+      expect(tokens[2]).toEqual value: '"', scopes: ['source.python', 'string.quoted.single.single-line.python', 'punctuation.definition.string.end.python']


### PR DESCRIPTION
### Description of the Change

Currently, the uppercase `DELETE` is a trigger to initiate coloring for embedded SQL. That comes into conflict with the HTTP request descriptions, where `DELETE` is one of the allowed methods.

So an API-describing string like:
```python
"""
GET /endpoint
POST /endpoint
DELETE /endpoint
PATCH /endpoint
"""
```
starts getting wrong highlighting starting from the DELETE keyword.
![image](https://user-images.githubusercontent.com/15035286/71558276-23e46e00-2a73-11ea-93e3-53809ef1796c.png)


This PR aims to cover this particular case of the occurence of `DELETE` in a string.

### Benefits

API descriptions in Python strings will look more appealing, and provided that servers are frequently written in Python, this is a considerable use case.

### Possible Drawbacks

Looks a little hacky.
