### PR TITLE
chore: Update tree-sitter-python

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -123,9 +123,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.14.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
+      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
     },
     "once": {
       "version": "1.4.0",
@@ -165,11 +165,11 @@
       "dev": true
     },
     "tree-sitter-python": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/tree-sitter-python/-/tree-sitter-python-0.17.0.tgz",
-      "integrity": "sha512-6HaqF/1GHB0/qrkcIxYqEELsQq6bXdQxx2KnGLZhoGn5ipbAibncSuQT9f8HYbmqLZ4dIGleQzsXreY1mx2lig==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/tree-sitter-python/-/tree-sitter-python-0.19.0.tgz",
+      "integrity": "sha512-UAJV73zCE+2b+X8XQOyL6C+MxVUV8BH0TxcOwhfgaDh6F6g4Ub0SqWGF19C1MDrGi25JNnZ8xlsH0aqrasyS3w==",
       "requires": {
-        "nan": "^2.4.0"
+        "nan": "^2.14.0"
       }
     },
     "wordwrap": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "atom-grammar-test": "^0.6.4",
-    "tree-sitter-python": "^0.17.0"
+    "tree-sitter-python": "^0.19.0"
   },
   "devDependencies": {
     "coffeelint": "^1.10.1"


### PR DESCRIPTION
### Description of the Change

This updates the `tree-sitter-python` dependency to it's latest version, which is compatible w/ the latest version of the tree-sitter ABI (ie 13). This is required if Atom is going to update to a newer version tree-sitter, and is a prerequisite for https://github.com/atom/atom/pull/23283. Tests are passing locally (on a mac) but note that the tree-sitter grammar for this package (like most other tree-sitter grammars) doesn't have any specific tests.

### Alternate Designs

n/a

### Benefits

Keeps dependencies up to date; allows Atom to keep it's dependencies up to date.

### Possible Drawbacks

If merged, this package will not work with Atom until it also updates to tree-sitter 0.19 or 0.20. This is no different than several other core packages ([language-javascript](https://github.com/atom/language-javascript), [language-css](https://github.com/atom/language-css), [language-go](https://github.com/atom/language-go) and [language-c](https://github.com/atom/language-c) are already updated) that are already updated but not technically compatible w/ Atom's current tree-sitter dependency.

### Applicable Issues

https://github.com/atom/language-shellscript/pull/172, https://github.com/atom/atom/pull/23283, https://github.com/atom/atom/issues/22129, https://github.com/icecream17/atom-update-backlog/blob/main/Languages.md
